### PR TITLE
Return ErrAlreadyExists when Put would overwrite existing data

### DIFF
--- a/id/standalone_test.go
+++ b/id/standalone_test.go
@@ -32,7 +32,7 @@ func manipulateUser(t *testing.T, uid uuid.UUID, standalone *Standalone) {
 	}
 
 	copy(userBytes[:5], make([]byte, 5))
-	if err := standalone.ioProvider.Put(uid, DataTypeSealedUser, userBytes); err != nil {
+	if err := standalone.ioProvider.Update(uid, DataTypeSealedUser, userBytes); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/io/bolt.go
+++ b/io/bolt.go
@@ -39,6 +39,9 @@ func NewBolt(path string) (Bolt, error) {
 func (b *Bolt) Put(id uuid.UUID, dataType DataType, data []byte) error {
 	return b.store.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(dataType.Bytes())
+		if b.Get(id.Bytes()) != nil {
+			return ErrAlreadyExists
+		}
 		return b.Put(id.Bytes(), data)
 	})
 }

--- a/io/bolt_test.go
+++ b/io/bolt_test.go
@@ -37,6 +37,30 @@ func TestBoltPutAndGet(t *testing.T) {
 	}
 }
 
+// Test that putting existing data returns the right error.
+func TestBoltPutAlreadyExists(t *testing.T) {
+	bolt, err := NewBolt(t.TempDir() + "test.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data := []byte("mock data")
+	id := uuid.Must(uuid.NewV4())
+
+	for dt := DataType(0); dt < DataTypeEnd; dt++ {
+		testData := append(data, dt.Bytes()...)
+		err := bolt.Put(id, dt, testData)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = bolt.Put(id, dt, testData)
+		if !errors.Is(err, ErrAlreadyExists) {
+			t.Fatalf("Expected %v but got %v", ErrAlreadyExists, err)
+		}
+	}
+}
+
 // Test that getting non-existing data returns the right error.
 func TestBoltNotFound(t *testing.T) {
 	bolt, err := NewBolt(t.TempDir() + "test.db")

--- a/io/io.go
+++ b/io/io.go
@@ -40,13 +40,14 @@ func (d DataType) String() string {
 // Provider is the interface an IO Provider must implement to handle data from Encryptonize.
 type Provider interface {
 	// Put sends bytes to the IO Provider. The data is identified by an ID and a data type.
+	// Should error if the data already exists in the IO Provider.
 	Put(id uuid.UUID, dataType DataType, data []byte) error
 
 	// Get fetches data from the IO Provider. The data is identified by an ID and a data type.
 	Get(id uuid.UUID, dataType DataType) ([]byte, error)
 
-	// Update is similar to Put but updates data previously sent to the IO Provider. Should error if
-	// the data does not exist in the IO Provider.
+	// Update is similar to Put but updates data previously sent to the IO Provider.
+	// Should error if the data does not exist in the IO Provider.
 	Update(id uuid.UUID, dataType DataType, data []byte) error
 
 	// Delete removes data previously sent to the IO Provider.

--- a/io/io.go
+++ b/io/io.go
@@ -13,6 +13,9 @@ import (
 // Error returned if data is not found during a "Get" or "Update" call.
 var ErrNotFound = errors.New("not found")
 
+// Error returned if data is found during a "Put" call.
+var ErrAlreadyExists = errors.New("already exists")
+
 // Types of data supported by an IO Provider.
 type DataType uint16
 

--- a/io/mem.go
+++ b/io/mem.go
@@ -17,33 +17,43 @@ func NewMem() Mem {
 	return Mem{sync.Map{}}
 }
 
+func newKey(id uuid.UUID, dataType DataType) string {
+	key := fmt.Sprintf("%s:%s", id.String(), dataType.String())
+	return key
+}
+
 func (m *Mem) Put(id uuid.UUID, dataType DataType, data []byte) error {
-	_, ok := m.data.Load(fmt.Sprintf("%s:%s", id.String(), dataType.String()))
+	key := newKey(id, dataType)
+	_, ok := m.data.Load(key)
 	if ok {
 		return ErrAlreadyExists
 	}
-	m.data.Store(fmt.Sprintf("%s:%s", id.String(), dataType.String()), data)
+	m.data.Store(key, data)
 	return nil
 }
 
 func (m *Mem) Get(id uuid.UUID, dataType DataType) ([]byte, error) {
-	out, ok := m.data.Load(fmt.Sprintf("%s:%s", id.String(), dataType.String()))
+	key := newKey(id, dataType)
+	out, ok := m.data.Load(key)
 	if !ok {
 		return nil, ErrNotFound
 	}
-	return out.([]byte), nil
+	data := out.([]byte)
+	return data, nil
 }
 
 func (m *Mem) Update(id uuid.UUID, dataType DataType, data []byte) error {
-	_, ok := m.data.Load(fmt.Sprintf("%s:%s", id.String(), dataType.String()))
+	key := newKey(id, dataType)
+	_, ok := m.data.Load(key)
 	if !ok {
 		return ErrNotFound
 	}
-	m.data.Store(fmt.Sprintf("%s:%s", id.String(), dataType.String()), data)
+	m.data.Store(key, data)
 	return nil
 }
 
 func (m *Mem) Delete(id uuid.UUID, dataType DataType) error {
-	m.data.Delete(fmt.Sprintf("%s:%s", id.String(), dataType.String()))
+	key := newKey(id, dataType)
+	m.data.Delete(key)
 	return nil
 }

--- a/io/mem.go
+++ b/io/mem.go
@@ -24,8 +24,7 @@ func newKey(id uuid.UUID, dataType DataType) string {
 
 func (m *Mem) Put(id uuid.UUID, dataType DataType, data []byte) error {
 	key := newKey(id, dataType)
-	_, ok := m.data.Load(key)
-	if ok {
+	if _, ok := m.data.Load(key); ok {
 		return ErrAlreadyExists
 	}
 	m.data.Store(key, data)
@@ -44,8 +43,7 @@ func (m *Mem) Get(id uuid.UUID, dataType DataType) ([]byte, error) {
 
 func (m *Mem) Update(id uuid.UUID, dataType DataType, data []byte) error {
 	key := newKey(id, dataType)
-	_, ok := m.data.Load(key)
-	if !ok {
+	if _, ok := m.data.Load(key); !ok {
 		return ErrNotFound
 	}
 	m.data.Store(key, data)

--- a/io/mem.go
+++ b/io/mem.go
@@ -18,6 +18,10 @@ func NewMem() Mem {
 }
 
 func (m *Mem) Put(id uuid.UUID, dataType DataType, data []byte) error {
+	_, ok := m.data.Load(fmt.Sprintf("%s:%s", id.String(), dataType.String()))
+	if ok {
+		return ErrAlreadyExists
+	}
 	m.data.Store(fmt.Sprintf("%s:%s", id.String(), dataType.String()), data)
 	return nil
 }
@@ -31,11 +35,12 @@ func (m *Mem) Get(id uuid.UUID, dataType DataType) ([]byte, error) {
 }
 
 func (m *Mem) Update(id uuid.UUID, dataType DataType, data []byte) error {
-	_, err := m.Get(id, dataType)
-	if err != nil {
-		return err
+	_, ok := m.data.Load(fmt.Sprintf("%s:%s", id.String(), dataType.String()))
+	if !ok {
+		return ErrNotFound
 	}
-	return m.Put(id, dataType, data)
+	m.data.Store(fmt.Sprintf("%s:%s", id.String(), dataType.String()), data)
+	return nil
 }
 
 func (m *Mem) Delete(id uuid.UUID, dataType DataType) error {

--- a/io/mem_test.go
+++ b/io/mem_test.go
@@ -34,6 +34,27 @@ func TestMemPutAndGet(t *testing.T) {
 	}
 }
 
+// Test that putting existing data returns the right error.
+func TestMemPutAlreadyExists(t *testing.T) {
+	mem := NewMem()
+
+	data := []byte("mock data")
+	id := uuid.Must(uuid.NewV4())
+
+	for dt := DataType(0); dt < DataTypeEnd; dt++ {
+		testData := append(data, dt.Bytes()...)
+		err := mem.Put(id, dt, testData)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = mem.Put(id, dt, testData)
+		if !errors.Is(err, ErrAlreadyExists) {
+			t.Fatalf("Expected %v but got %v", ErrAlreadyExists, err)
+		}
+	}
+}
+
 // Test that getting non-existing data returns the right error.
 func TestMemNotFound(t *testing.T) {
 	mem := NewMem()


### PR DESCRIPTION
### Description

This PR includes the additional of a new kind of error, which should be returned when a `Put` call on an IO Provider would result in an overwrite. Clients should use `Update` when overwrites are intended.

Descriptions, tests and implementations have been updated to conform to this expected behavior which is now more explicitly stated.

### Relevant Issues/PRs

This is related to an upcoming PR in encryptonize-objects.

### Type(s) of Change (Split the PR if you check many)

- [ ] Added user feature
- [x] Added technical feature
- [x] Added tests
- [x] Refactor
- [ ] Bugfix
- [ ] Updated documentation
- [ ] Kubernetes changes
- [ ] CI/CD workflow changes

### Testing Checklist

- [x] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist

- [x] I have pulled in the latest changes from master.
- [x] I have run `make lint`.
- [x] I have successfully run `make tests`.
- [ ] I have updated relevant CI/CD workflows.
- [ ] I have updated relevant Kubernetes manifests/scripts.
- [ ] I have updated/added relevant (internal and external) documentation (readme, doc comments, etc).
- [ ] I have updated the dependency map to reflect my changes.
- [ ] I have added the license to new source code files.
- [x] I have spent some time looking over the full diff before creating this PR.

### Technical Debt

None.