### PR TITLE
Can give more scopes to new group

### DIFF
--- a/id/standalone.go
+++ b/id/standalone.go
@@ -216,7 +216,7 @@ func (s *Standalone) RemoveUserFromGroups(token string, uid uuid.UUID, gids ...u
 }
 
 // NewGroup creates a new group and adds the calling user to it.
-func (s *Standalone) NewGroup(token string, scopes Scope) (uuid.UUID, error) {
+func (s *Standalone) NewGroup(token string, scopes ...Scope) (uuid.UUID, error) {
 	identity, err := s.GetIdentity(token)
 	if err != nil {
 		return uuid.Nil, err
@@ -227,7 +227,7 @@ func (s *Standalone) NewGroup(token string, scopes Scope) (uuid.UUID, error) {
 		return uuid.Nil, err
 	}
 
-	group := NewGroup(scopes)
+	group := NewGroup(scopes...)
 	if err := s.putGroup(gid, &group); err != nil {
 		return uuid.Nil, err
 	}

--- a/id/standalone_group.go
+++ b/id/standalone_group.go
@@ -36,8 +36,8 @@ type SealedGroup struct {
 }
 
 // NewGroup creates a new group which has the given scopes.
-func NewGroup(scopes Scope) Group {
-	return Group{scopes}
+func NewGroup(scopes ...Scope) Group {
+	return Group{Scopes: ScopeUnion(scopes...)}
 }
 
 // Seal encrypts the group.

--- a/id/standalone_group.go
+++ b/id/standalone_group.go
@@ -35,13 +35,13 @@ type SealedGroup struct {
 	WrappedKey []byte
 }
 
-// NewGroup creates a new group which has the given scopes.
-func NewGroup(scopes ...Scope) Group {
+// newGroup creates a new group which has the given scopes.
+func newGroup(scopes ...Scope) Group {
 	return Group{Scopes: ScopeUnion(scopes...)}
 }
 
-// Seal encrypts the group.
-func (g *Group) Seal(gid uuid.UUID, cryptor crypto.CryptorInterface) (SealedGroup, error) {
+// seal encrypts the group.
+func (g *Group) seal(gid uuid.UUID, cryptor crypto.CryptorInterface) (SealedGroup, error) {
 	wrappedKey, ciphertext, err := cryptor.Encrypt(g, gid.Bytes())
 	if err != nil {
 		return SealedGroup{}, err
@@ -50,8 +50,8 @@ func (g *Group) Seal(gid uuid.UUID, cryptor crypto.CryptorInterface) (SealedGrou
 	return SealedGroup{gid, ciphertext, wrappedKey}, nil
 }
 
-// Unseal decrypts the sealed group.
-func (g *SealedGroup) Unseal(cryptor crypto.CryptorInterface) (Group, error) {
+// unseal decrypts the sealed group.
+func (g *SealedGroup) unseal(cryptor crypto.CryptorInterface) (Group, error) {
 	plainGroup := Group{}
 	if err := cryptor.Decrypt(&plainGroup, g.GID.Bytes(), g.WrappedKey, g.Ciphertext); err != nil {
 		return Group{}, err
@@ -59,8 +59,8 @@ func (g *SealedGroup) Unseal(cryptor crypto.CryptorInterface) (Group, error) {
 	return plainGroup, nil
 }
 
-// Verify checks the integrity of the sealed group.
-func (g *SealedGroup) Verify(cryptor crypto.CryptorInterface) bool {
-	_, err := g.Unseal(cryptor)
+// verify checks the integrity of the sealed group.
+func (g *SealedGroup) verify(cryptor crypto.CryptorInterface) bool {
+	_, err := g.unseal(cryptor)
 	return err == nil
 }

--- a/id/standalone_group_test.go
+++ b/id/standalone_group_test.go
@@ -30,13 +30,13 @@ func TestGroupSeal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	group := NewGroup(ScopeEncrypt)
-	sealed, err := group.Seal(uuid.Must(uuid.NewV4()), &cryptor)
+	group := newGroup(ScopeEncrypt)
+	sealed, err := group.seal(uuid.Must(uuid.NewV4()), &cryptor)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	unsealed, err := sealed.Unseal(&cryptor)
+	unsealed, err := sealed.unseal(&cryptor)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,17 +52,17 @@ func TestGroupVerifyCiphertext(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	group := NewGroup(ScopeEncrypt)
-	sealed, err := group.Seal(uuid.Must(uuid.NewV4()), &cryptor)
+	group := newGroup(ScopeEncrypt)
+	sealed, err := group.seal(uuid.Must(uuid.NewV4()), &cryptor)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !sealed.Verify(&cryptor) {
+	if !sealed.verify(&cryptor) {
 		t.Fatal("Verification failed")
 	}
 	sealed.Ciphertext[0] = sealed.Ciphertext[0] ^ 1
-	if sealed.Verify(&cryptor) {
+	if sealed.verify(&cryptor) {
 		t.Fatal("Verification should have failed")
 	}
 }
@@ -74,17 +74,17 @@ func TestGroupVerifyID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	group := NewGroup(ScopeEncrypt)
-	sealed, err := group.Seal(uuid.Must(uuid.NewV4()), &cryptor)
+	group := newGroup(ScopeEncrypt)
+	sealed, err := group.seal(uuid.Must(uuid.NewV4()), &cryptor)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !sealed.Verify(&cryptor) {
+	if !sealed.verify(&cryptor) {
 		t.Fatal("Verification failed")
 	}
 	sealed.GID = uuid.Must(uuid.NewV4())
-	if sealed.Verify(&cryptor) {
+	if sealed.verify(&cryptor) {
 		t.Fatal("Verification should have failed")
 	}
 }
@@ -96,12 +96,12 @@ func TestGroupID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	group := NewGroup(ScopeEncrypt)
-	sealed1, err := group.Seal(uuid.Must(uuid.NewV4()), &cryptor)
+	group := newGroup(ScopeEncrypt)
+	sealed1, err := group.seal(uuid.Must(uuid.NewV4()), &cryptor)
 	if err != nil {
 		t.Fatal(err)
 	}
-	sealed2, err := group.Seal(uuid.Must(uuid.NewV4()), &cryptor)
+	sealed2, err := group.seal(uuid.Must(uuid.NewV4()), &cryptor)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/id/standalone_user_test.go
+++ b/id/standalone_user_test.go
@@ -31,85 +31,85 @@ var userGroups = []uuid.UUID{
 }
 
 func TestGetGroupIDs(t *testing.T) {
-	user, _, err := NewUser(ScopeEncrypt)
+	user, _, err := newUser(ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
 	groupID := uuid.Must(uuid.NewV4())
-	user.AddGroups(groupID)
+	user.addGroups(groupID)
 
-	uuids := user.GetGroups()
+	uuids := user.getGroups()
 	if _, ok := uuids[groupID]; len(uuids) == 0 || !ok {
 		t.Error("Expected GetGroups to return a group ID")
 	}
 }
 
 func TestGetZeroGroupIDs(t *testing.T) {
-	user, _, err := NewUser(ScopeEncrypt)
+	user, _, err := newUser(ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	uuids := user.GetGroups()
+	uuids := user.getGroups()
 	if len(uuids) != 0 {
 		t.Error("GetGroups should have returned empty array")
 	}
 }
 
 func TestUserContainsGroup(t *testing.T) {
-	user, _, err := NewUser(ScopeEncrypt)
+	user, _, err := newUser(ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
-	user.AddGroups(userGroups...)
+	user.addGroups(userGroups...)
 
-	if !user.ContainsGroups(userGroups...) {
+	if !user.containsGroups(userGroups...) {
 		t.Error("ContainsGroup returned false")
 	}
 
-	if user.ContainsGroups(uuid.Must(uuid.NewV4())) {
+	if user.containsGroups(uuid.Must(uuid.NewV4())) {
 		t.Error("ContainsGroup returned true")
 	}
 }
 
 func TestUserAdd(t *testing.T) {
-	user, _, err := NewUser(ScopeEncrypt)
+	user, _, err := newUser(ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for i := 0; i < 256; i++ {
 		g := uuid.Must(uuid.NewV4())
-		user.AddGroups(g)
-		if !user.ContainsGroups(g) {
+		user.addGroups(g)
+		if !user.containsGroups(g) {
 			t.Error("AddGroup failed")
 		}
 	}
 }
 
 func TestUserAddDuplicate(t *testing.T) {
-	user, _, err := NewUser(ScopeEncrypt)
+	user, _, err := newUser(ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
 	g := uuid.Must(uuid.NewV4())
-	user.AddGroups(g)
-	user.AddGroups(g)
-	if !user.ContainsGroups(g) {
+	user.addGroups(g)
+	user.addGroups(g)
+	if !user.containsGroups(g) {
 		t.Error("calling AddGroup twice with same ID failed")
 	}
 }
 
 func TestUserRemoveGroup(t *testing.T) {
-	user, _, err := NewUser(ScopeEncrypt)
+	user, _, err := newUser(ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
-	user.AddGroups(userGroups...)
+	user.addGroups(userGroups...)
 
 	for _, g := range userGroups {
-		user.RemoveGroups(g)
-		if user.ContainsGroups(g) {
+		user.removeGroups(g)
+		if user.containsGroups(g) {
 			t.Error("RemoveGroup failed")
 		}
 	}
@@ -122,14 +122,14 @@ func TestUserSeal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	user, _, err := NewUser(ScopeEncrypt)
+	user, _, err := newUser(ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
-	user.AddGroups(userGroups...)
+	user.addGroups(userGroups...)
 
 	id := uuid.Must(uuid.NewV4())
-	sealed, err := user.Seal(id, &cryptor)
+	sealed, err := user.seal(id, &cryptor)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,7 +137,7 @@ func TestUserSeal(t *testing.T) {
 		t.Fatalf("Wrong ID: %s != %s", sealed.UID, id)
 	}
 
-	unsealed, err := sealed.Unseal(&cryptor)
+	unsealed, err := sealed.unseal(&cryptor)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,23 +153,23 @@ func TestUserVerifyCiphertext(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	user, _, err := NewUser(ScopeEncrypt)
+	user, _, err := newUser(ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
-	user.AddGroups(userGroups...)
+	user.addGroups(userGroups...)
 
 	id := uuid.Must(uuid.NewV4())
-	sealed, err := user.Seal(id, &cryptor)
+	sealed, err := user.seal(id, &cryptor)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !sealed.Verify(&cryptor) {
+	if !sealed.verify(&cryptor) {
 		t.Fatal("Verification failed")
 	}
 	sealed.Ciphertext[0] = sealed.Ciphertext[0] ^ 1
-	if sealed.Verify(&cryptor) {
+	if sealed.verify(&cryptor) {
 		t.Fatal("Verification should have failed")
 	}
 }
@@ -181,88 +181,88 @@ func TestUserVerifyID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	user, _, err := NewUser(ScopeEncrypt)
+	user, _, err := newUser(ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
-	user.AddGroups(userGroups...)
+	user.addGroups(userGroups...)
 
 	id := uuid.Must(uuid.NewV4())
-	sealed, err := user.Seal(id, &cryptor)
+	sealed, err := user.seal(id, &cryptor)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !sealed.Verify(&cryptor) {
+	if !sealed.verify(&cryptor) {
 		t.Fatal("Verification failed")
 	}
 	sealed.UID = uuid.Must(uuid.NewV4())
-	if sealed.Verify(&cryptor) {
+	if sealed.verify(&cryptor) {
 		t.Fatal("Verification should have failed")
 	}
 }
 
 func TestUserAuth(t *testing.T) {
-	user, pwd, err := NewUser(ScopeEncrypt)
+	user, pwd, err := newUser(ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := user.Authenticate(pwd); err != nil {
+	if err := user.authenticate(pwd); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestUserAuthWrongPwd(t *testing.T) {
-	user, _, err := NewUser(ScopeEncrypt)
+	user, _, err := newUser(ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := user.Authenticate("wrong password"); err == nil {
+	if err := user.authenticate("wrong password"); err == nil {
 		t.Fatal("User authentication with a wrong password should fail")
 	}
 }
 
 func TestChangePwd(t *testing.T) {
-	user, pwd, err := NewUser(ScopeEncrypt)
+	user, pwd, err := newUser(ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	newPwd, err := user.ChangePassword(pwd)
+	newPwd, err := user.changePassword(pwd)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := user.Authenticate(newPwd); err != nil {
+	if err := user.authenticate(newPwd); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestChangePwdWrongPwd(t *testing.T) {
-	user, _, err := NewUser(ScopeEncrypt)
+	user, _, err := newUser(ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := user.ChangePassword("wrong password"); err == nil {
+	if _, err := user.changePassword("wrong password"); err == nil {
 		t.Fatal("User must provide his correct password in order to change it")
 	}
 }
 
 func TestChangePwdAuthWithOldPwd(t *testing.T) {
-	user, pwd, err := NewUser(ScopeEncrypt)
+	user, pwd, err := newUser(ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = user.ChangePassword(pwd)
+	_, err = user.changePassword(pwd)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := user.Authenticate(pwd); err == nil {
+	if err := user.authenticate(pwd); err == nil {
 		t.Fatal("User authentication with old password after password change should fail")
 	}
 }


### PR DESCRIPTION
### Description

- This PR changes the Group constructor in the Standalone ID provider so that it can take more than one scope.
- It also unexports the User and Group methods from the Standalone id provider so that only the methods of the Standalone struct are exported

### Relevant Issues/PRs

Closes #xxx
PR #xxx

### Type(s) of Change (Split the PR if you check many)

- [ ] Added user feature
- [ ] Added technical feature
- [ ] Added tests
- [ ] Refactor
- [x] Bugfix
- [ ] Updated documentation
- [ ] Kubernetes changes
- [ ] CI/CD workflow changes

### Testing Checklist

- [ ] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist

- [x] I have pulled in the latest changes from master.
- [x] I have run `make lint`.
- [x] I have successfully run `make tests`.
- [ ] I have updated relevant CI/CD workflows.
- [ ] I have updated relevant Kubernetes manifests/scripts.
- [ ] I have updated/added relevant (internal and external) documentation (readme, doc comments, etc).
- [ ] I have updated the dependency map to reflect my changes.
- [ ] I have added the license to new source code files.
- [ ] I have spent some time looking over the full diff before creating this PR.

### Technical Debt

(Please create new issues if there is technical debt - otherwise delete this section)
Issue #xxx
