### PR TITLE
Implement Delete in Lib

### DIFF
--- a/encryptonize.go
+++ b/encryptonize.go
@@ -94,6 +94,9 @@ func New(keyProvider key.Provider, ioProvider io.Provider, idProvider id.Provide
 //
 // For all practical purposes, the size of the ciphertext in the SealedObject is len(plaintext) + 48
 // bytes.
+//
+// Required scopes:
+// - Encrypt
 func (e *Encryptonize) Encrypt(token string, object *data.Object) (uuid.UUID, error) {
 	identity, err := e.idProvider.GetIdentity(token)
 	if err != nil {
@@ -136,6 +139,9 @@ func (e *Encryptonize) Encrypt(token string, object *data.Object) (uuid.UUID, er
 // provided access list, either directly or through group membership.
 //
 // The input ID is the identifier obtained by previously calling Encrypt.
+//
+// Required scopes:
+// - Update
 func (e *Encryptonize) Update(token string, oid uuid.UUID, object *data.Object) error {
 	identity, err := e.idProvider.GetIdentity(token)
 	if err != nil {
@@ -183,6 +189,9 @@ func (e *Encryptonize) Update(token string, oid uuid.UUID, object *data.Object) 
 // The input ID is the identifier obtained by previously calling Encrypt.
 //
 // The unsealed object may contain sensitive data.
+//
+// Required scopes:
+// - Decrypt
 func (e *Encryptonize) Decrypt(token string, oid uuid.UUID) (data.Object, error) {
 	identity, err := e.idProvider.GetIdentity(token)
 	if err != nil {
@@ -213,6 +222,9 @@ func (e *Encryptonize) Decrypt(token string, oid uuid.UUID) (data.Object, error)
 // the provided access list, either directly or through group membership.
 //
 // The input ID is the identifier obtained by previously calling Encrypt.
+//
+// Required scopes:
+// - Delete
 func (e *Encryptonize) Delete(token string, oid uuid.UUID) error {
 	identity, err := e.idProvider.GetIdentity(token)
 	if err != nil {
@@ -276,6 +288,9 @@ func (e *Encryptonize) GetTokenContents(token *data.SealedToken) ([]byte, error)
 //
 // The set of group IDs is somewhat sensitive data, as it reveals what groups/users have access to
 // the associated object.
+//
+// Required scopes:
+// - GetAccessGroups
 func (e *Encryptonize) GetAccessGroups(token string, oid uuid.UUID) (map[uuid.UUID]struct{}, error) {
 	identity, err := e.idProvider.GetIdentity(token)
 	if err != nil {
@@ -302,6 +317,9 @@ func (e *Encryptonize) GetAccessGroups(token string, oid uuid.UUID) (map[uuid.UU
 // the associated object. The authorizing user must be part of the access list.
 //
 // The input ID is the identifier obtained by previously calling Encrypt.
+//
+// Required scopes:
+// - ModifyAccessGroups
 func (e *Encryptonize) AddGroupsToAccess(token string, oid uuid.UUID, groups ...uuid.UUID) error {
 	identity, err := e.idProvider.GetIdentity(token)
 	if err != nil {
@@ -334,6 +352,9 @@ func (e *Encryptonize) AddGroupsToAccess(token string, oid uuid.UUID, groups ...
 // from accessing the associated object. The authorizing user must be part of the access object.
 //
 // The input ID is the identifier obtained by previously calling Encrypt.
+//
+// Required scopes:
+// - ModifyAccessGroups
 func (e *Encryptonize) RemoveGroupsFromAccess(token string, oid uuid.UUID, groups ...uuid.UUID) error {
 	identity, err := e.idProvider.GetIdentity(token)
 	if err != nil {
@@ -367,6 +388,9 @@ func (e *Encryptonize) RemoveGroupsFromAccess(token string, oid uuid.UUID, group
 // authorized.
 //
 // The input ID is the identifier obtained by previously calling Encrypt.
+//
+// Required scopes:
+// - GetAccessGroups
 func (e *Encryptonize) AuthorizeUser(token string, oid uuid.UUID) error {
 	identity, err := e.idProvider.GetIdentity(token)
 	if err != nil {

--- a/encryptonize_test.go
+++ b/encryptonize_test.go
@@ -370,6 +370,133 @@ func TestUpdateWrongGroupScope(t *testing.T) {
 }
 
 ////////////////////////////////////////////////////////
+//                       Delete                       //
+////////////////////////////////////////////////////////
+
+// It is verified that an object is correctly encrypted and deleted.
+func TestDelete(t *testing.T) {
+	enc := newTestEncryptonize(t)
+	_, token := newTestUser(t, &enc, id.ScopeEncrypt, id.ScopeDecrypt, id.ScopeDelete)
+
+	plainObject := data.Object{
+		Plaintext:      []byte("plaintext"),
+		AssociatedData: []byte("associated_data"),
+	}
+
+	id, err := enc.Encrypt(token, &plainObject)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = enc.Delete(token, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	object, err := enc.Decrypt(token, id)
+	if !errors.Is(err, io.ErrNotFound) {
+		t.Fatalf("Expected error '%s' but got '%s'", io.ErrNotFound, err)
+	}
+	if !reflect.DeepEqual(object, data.Object{}) {
+		t.Fatal("Data was returned from failed call")
+	}
+
+	sealedAccess, err := enc.ioProvider.Get(id, io.DataTypeSealedAccess)
+	if !errors.Is(err, io.ErrNotFound) {
+		t.Fatalf("Expected error '%s' but got '%s'", io.ErrNotFound, err)
+	}
+	if sealedAccess != nil {
+		t.Fatal("Data was returned from failed call")
+	}
+
+	sealedObject, err := enc.ioProvider.Get(id, io.DataTypeSealedObject)
+	if !errors.Is(err, io.ErrNotFound) {
+		t.Fatalf("Expected error '%s' but got '%s'", io.ErrNotFound, err)
+	}
+	if sealedObject != nil {
+		t.Fatal("Data was returned from failed call")
+	}
+}
+
+// It is verified that an unauthenticated user is not able to delete.
+func TestDeleteUnauthenticated(t *testing.T) {
+	enc := newTestEncryptonize(t)
+
+	err := enc.Delete("bad token", uuid.Must(uuid.NewV4()))
+	if !errors.Is(err, ErrNotAuthenticated) {
+		t.Fatalf("Expected error '%s' but got '%s'", ErrNotAuthenticated, err)
+	}
+}
+
+// It is verified that an unauthorized user is not able to delete.
+func TestDeleteUnauthorizedUser(t *testing.T) {
+	enc := newTestEncryptonize(t)
+	_, token1 := newTestUser(t, &enc, id.ScopeEncrypt)
+	_, token2 := newTestUser(t, &enc, id.ScopeDecrypt)
+
+	plainObject := data.Object{
+		Plaintext:      []byte("plaintext"),
+		AssociatedData: []byte("associated_data"),
+	}
+
+	oid, err := enc.Encrypt(token1, &plainObject)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = enc.Delete(token2, oid); err == nil {
+		t.Fatal("Unauthorized user was able to delete")
+	}
+}
+
+// Test that a user without the Delete scope cannot delete.
+func TestDeleteWrongAPIScope(t *testing.T) {
+	enc := newTestEncryptonize(t)
+	scope := id.ScopeAll ^ id.ScopeDelete // All scopes except Decrypt
+	_, token := newTestUser(t, &enc, scope)
+
+	err := enc.Delete(token, uuid.Must(uuid.NewV4()))
+	if !errors.Is(err, ErrNotAuthorized) {
+		t.Fatalf("Expected error '%s' but got '%s'", ErrNotAuthorized, err)
+	}
+}
+
+// Test that a user whose group does not have the Delete scope cannot delete.
+func TestDeleteWrongGroupScope(t *testing.T) {
+	enc := newTestEncryptonize(t)
+	_, token1 := newTestUser(t, &enc, id.ScopeAll)
+	user2, token2 := newTestUser(t, &enc, id.ScopeAll)
+
+	// User2 has all scopes themselves, but get access to the object through a group with a missing
+	// scope.
+	scope := id.ScopeAll ^ id.ScopeDelete // All scopes except Decrypt
+	gid := newTestGroup(t, &enc, token1, scope, user2)
+
+	oid, err := enc.Encrypt(token1, &data.Object{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.AddGroupsToAccess(token1, oid, gid); err != nil {
+		t.Fatal(err)
+	}
+
+	err = enc.Delete(token2, oid)
+	if !errors.Is(err, ErrNotAuthorized) {
+		t.Fatalf("Expected error '%s' but got '%s'", ErrNotAuthorized, err)
+	}
+}
+
+// Test that an appropriate error is returned when a user tries to delete an object that does not exist.
+func TestDeleteNotFound(t *testing.T) {
+	enc := newTestEncryptonize(t)
+	_, token := newTestUser(t, &enc, id.ScopeDelete)
+
+	err := enc.Delete(token, uuid.Must(uuid.NewV4()))
+	if !errors.Is(err, io.ErrNotFound) {
+		t.Fatalf("Expected error '%s' but got '%s'", io.ErrNotFound, err)
+	}
+}
+
+////////////////////////////////////////////////////////
 //            CreateToken/GetTokenContents            //
 ////////////////////////////////////////////////////////
 

--- a/encryptonize_test.go
+++ b/encryptonize_test.go
@@ -134,6 +134,7 @@ func TestPlainObject(t *testing.T) {
 	}
 }
 
+// It is verified that an unauthenticated user is not able to encrypt.
 func TestEncryptUnauthenticated(t *testing.T) {
 	enc := newTestEncryptonize(t)
 	oid, err := enc.Encrypt("bad token", &data.Object{})
@@ -187,6 +188,7 @@ func TestDecrypt(t *testing.T) {
 	}
 }
 
+// It is verified that an unauthenticated user is not able to decrypt.
 func TestDecryptUnauthenticated(t *testing.T) {
 	enc := newTestEncryptonize(t)
 	object, err := enc.Decrypt("bad token", uuid.Must(uuid.NewV4()))
@@ -198,6 +200,7 @@ func TestDecryptUnauthenticated(t *testing.T) {
 	}
 }
 
+// It is verified that an unauthorized user is not able to decrypt.
 func TestDecryptUnauthorizedUser(t *testing.T) {
 	enc := newTestEncryptonize(t)
 	_, token1 := newTestUser(t, &enc, id.ScopeEncrypt)
@@ -298,6 +301,7 @@ func TestUpdate(t *testing.T) {
 	}
 }
 
+// It is verified that an unauthenticated user is not able to update.
 func TestUpdateUnauthenticated(t *testing.T) {
 	enc := newTestEncryptonize(t)
 	err := enc.Update("bad token", uuid.Must(uuid.NewV4()), &data.Object{})

--- a/encryptonize_test.go
+++ b/encryptonize_test.go
@@ -369,6 +369,22 @@ func TestUpdateWrongGroupScope(t *testing.T) {
 	}
 }
 
+// Test that an appropriate error is returned when a user tries to update an object that does not exist.
+func TestUpdateNotFound(t *testing.T) {
+	enc := newTestEncryptonize(t)
+	_, token := newTestUser(t, &enc, id.ScopeUpdate)
+
+	plainObjectUpdated := data.Object{
+		Plaintext:      []byte("plaintext_updated"),
+		AssociatedData: []byte("associated_data_updated"),
+	}
+
+	err := enc.Update(token, uuid.Must(uuid.NewV4()), &plainObjectUpdated)
+	if !errors.Is(err, io.ErrNotFound) {
+		t.Fatalf("Expected error '%s' but got '%s'", io.ErrNotFound, err)
+	}
+}
+
 ////////////////////////////////////////////////////////
 //                       Delete                       //
 ////////////////////////////////////////////////////////

--- a/encryptonize_test.go
+++ b/encryptonize_test.go
@@ -420,6 +420,7 @@ func TestDelete(t *testing.T) {
 		t.Fatal("Data was returned from failed call")
 	}
 
+	// Double-check with the IO Provider that the sealed access is gone.
 	sealedAccess, err := enc.ioProvider.Get(id, io.DataTypeSealedAccess)
 	if !errors.Is(err, io.ErrNotFound) {
 		t.Fatalf("Expected error '%s' but got '%s'", io.ErrNotFound, err)
@@ -428,6 +429,7 @@ func TestDelete(t *testing.T) {
 		t.Fatal("Data was returned from failed call")
 	}
 
+	// Double-check with the IO Provider that the sealed object is gone.
 	sealedObject, err := enc.ioProvider.Get(id, io.DataTypeSealedObject)
 	if !errors.Is(err, io.ErrNotFound) {
 		t.Fatalf("Expected error '%s' but got '%s'", io.ErrNotFound, err)

--- a/id/scope.go
+++ b/id/scope.go
@@ -22,6 +22,7 @@ const ScopeNone Scope = 0
 const ScopeAll Scope = ScopeEncrypt |
 	ScopeDecrypt |
 	ScopeUpdate |
+	ScopeDelete |
 	ScopeCreateToken |
 	ScopeGetTokenContents |
 	ScopeGetAccessGroups |
@@ -31,6 +32,7 @@ const (
 	ScopeEncrypt Scope = 1 << iota
 	ScopeDecrypt
 	ScopeUpdate
+	ScopeDelete
 	ScopeCreateToken
 	ScopeGetTokenContents
 	ScopeGetAccessGroups

--- a/id/scope.go
+++ b/id/scope.go
@@ -19,14 +19,7 @@ type Scope uint64
 
 const ScopeNone Scope = 0
 
-const ScopeAll Scope = ScopeEncrypt |
-	ScopeDecrypt |
-	ScopeUpdate |
-	ScopeDelete |
-	ScopeCreateToken |
-	ScopeGetTokenContents |
-	ScopeGetAccessGroups |
-	ScopeModifyAccessGroups
+const ScopeAll Scope = ScopeEnd - 1
 
 const (
 	ScopeEncrypt Scope = 1 << iota

--- a/utility.go
+++ b/utility.go
@@ -83,7 +83,7 @@ func (e *Encryptonize) getSealedObject(oid uuid.UUID) (*data.SealedObject, error
 
 // deleteSealedObject deletes a sealed object from the IO Provider.
 func (e *Encryptonize) deleteSealedObject(oid uuid.UUID) error {
-return e.ioProvider.Delete(oid, io.DataTypeSealedObject)
+	return e.ioProvider.Delete(oid, io.DataTypeSealedObject)
 }
 
 // putSealedAccess encodes a sealed access and sends it to the IO Provider, either as a "Put" or an
@@ -121,5 +121,5 @@ func (e *Encryptonize) getSealedAccess(oid uuid.UUID) (*data.SealedAccess, error
 
 // deleteSealedAccess deletes a sealed object from the IO Provider.
 func (e *Encryptonize) deleteSealedAccess(oid uuid.UUID) error {
-return e.ioProvider.Delete(oid, io.DataTypeSealedAccess)
+	return e.ioProvider.Delete(oid, io.DataTypeSealedAccess)
 }

--- a/utility.go
+++ b/utility.go
@@ -83,8 +83,7 @@ func (e *Encryptonize) getSealedObject(oid uuid.UUID) (*data.SealedObject, error
 
 // deleteSealedObject deletes a sealed object from the IO Provider.
 func (e *Encryptonize) deleteSealedObject(oid uuid.UUID) error {
-	err := e.ioProvider.Delete(oid, io.DataTypeSealedObject)
-	return err
+return e.ioProvider.Delete(oid, io.DataTypeSealedObject)
 }
 
 // putSealedAccess encodes a sealed access and sends it to the IO Provider, either as a "Put" or an
@@ -122,6 +121,5 @@ func (e *Encryptonize) getSealedAccess(oid uuid.UUID) (*data.SealedAccess, error
 
 // deleteSealedAccess deletes a sealed object from the IO Provider.
 func (e *Encryptonize) deleteSealedAccess(oid uuid.UUID) error {
-	err := e.ioProvider.Delete(oid, io.DataTypeSealedAccess)
-	return err
+return e.ioProvider.Delete(oid, io.DataTypeSealedAccess)
 }

--- a/utility.go
+++ b/utility.go
@@ -81,6 +81,12 @@ func (e *Encryptonize) getSealedObject(oid uuid.UUID) (*data.SealedObject, error
 	return object, nil
 }
 
+// deleteSealedObject deletes a sealed object from the IO Provider.
+func (e *Encryptonize) deleteSealedObject(oid uuid.UUID) error {
+	err := e.ioProvider.Delete(oid, io.DataTypeSealedObject)
+	return err
+}
+
 // putSealedAccess encodes a sealed access and sends it to the IO Provider, either as a "Put" or an
 // "Update".
 func (e *Encryptonize) putSealedAccess(access *data.SealedAccess, update bool) error {
@@ -112,4 +118,10 @@ func (e *Encryptonize) getSealedAccess(oid uuid.UUID) (*data.SealedAccess, error
 
 	access.OID = oid
 	return access, nil
+}
+
+// deleteSealedAccess deletes a sealed object from the IO Provider.
+func (e *Encryptonize) deleteSealedAccess(oid uuid.UUID) error {
+	err := e.ioProvider.Delete(oid, io.DataTypeSealedAccess)
+	return err
 }


### PR DESCRIPTION
### Description

This PR adds a Delete method to the lib, to support deletion of objects.
Without this, clients of the library (such as Generic and Storage) would have to implement deletion themselves, by using the IO Provider directly, define their own custom scopes to control authorization to delete, and check for these scopes themselves.

### Relevant Issues/PRs

Closes DEV-239

### Type(s) of Change (Split the PR if you check many)

- [ ] Added user feature
- [x] Added technical feature
- [x] Added tests
- [ ] Refactor
- [ ] Bugfix
- [ ] Updated documentation
- [ ] Kubernetes changes
- [ ] CI/CD workflow changes

### Testing Checklist

- [x] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist

- [x] I have pulled in the latest changes from master.
- [x] I have run `make lint`.
- [x] I have successfully run `make tests`.
- [ ] I have updated relevant CI/CD workflows.
- [ ] I have updated relevant Kubernetes manifests/scripts.
- [ ] I have updated/added relevant (internal and external) documentation (readme, doc comments, etc).
- [ ] I have updated the dependency map to reflect my changes.
- [ ] I have added the license to new source code files.
- [x] I have spent some time looking over the full diff before creating this PR.

### Technical Debt

None.
