### PR TITLE
Improve delete functionality

### DIFF
--- a/encryptonize.go
+++ b/encryptonize.go
@@ -240,7 +240,10 @@ func (e *Encryptonize) Delete(token string, oid uuid.UUID) error {
 		// Ignore and proceed
 	case io.ErrNotFound:
 		// If we can't find the access, that should mean the sealed object
-		// doesn't exist. In which case, what the client wanted, has already
+		// doesn't exist, either because it never existed, or it has been completely deleted.
+		// Because the sealed access is deleted last as the step in a deletion
+		// (see further below) we know that a deleted access entry also implies a deleted object.
+		// In either case, what the client wanted has already
 		// been achieved, and so we return with no error.
 		return nil
 	default:

--- a/encryptonize.go
+++ b/encryptonize.go
@@ -241,7 +241,7 @@ func (e *Encryptonize) Delete(token string, oid uuid.UUID) error {
 	case io.ErrNotFound:
 		// If we can't find the access, that should mean the sealed object
 		// doesn't exist. In which case, what the client wanted, has already
-		// been achived, and so we return with no error.
+		// been achieved, and so we return with no error.
 		return nil
 	default:
 		return err

--- a/encryptonize.go
+++ b/encryptonize.go
@@ -235,7 +235,15 @@ func (e *Encryptonize) Delete(token string, oid uuid.UUID) error {
 	}
 
 	access, err := e.getSealedAccess(oid)
-	if err != nil {
+	switch err {
+	case nil:
+		// Ignore and proceed
+	case io.ErrNotFound:
+		// If we can't find the access, that should mean the sealed object
+		// doesn't exist. In which case, what the client wanted, has already
+		// been achived, and so we return with no error.
+		return nil
+	default:
 		return err
 	}
 

--- a/encryptonize_test.go
+++ b/encryptonize_test.go
@@ -398,7 +398,6 @@ func TestUpdateNotFound(t *testing.T) {
 
 func checkDataIsDeleted(t *testing.T, ioProvider io.Provider, id uuid.UUID, dataTypes ...io.DataType) {
 	for _, dataType := range dataTypes {
-
 		sealedData, err := ioProvider.Get(id, dataType)
 		if !errors.Is(err, io.ErrNotFound) {
 			t.Fatalf("Expected error '%s' but got '%s'", io.ErrNotFound, err)

--- a/encryptonize_test.go
+++ b/encryptonize_test.go
@@ -441,6 +441,32 @@ func TestDelete(t *testing.T) {
 	}
 }
 
+// It is verified that no errors are returned when deleting a deleted object.
+func TestDeleteTwice(t *testing.T) {
+	enc := newTestEncryptonize(t)
+	_, token := newTestUser(t, &enc, id.ScopeEncrypt, id.ScopeDecrypt, id.ScopeDelete)
+
+	plainObject := data.Object{
+		Plaintext:      []byte("plaintext"),
+		AssociatedData: []byte("associated_data"),
+	}
+
+	id, err := enc.Encrypt(token, &plainObject)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = enc.Delete(token, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = enc.Delete(token, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 // It is verified that an unauthenticated user is not able to delete.
 func TestDeleteUnauthenticated(t *testing.T) {
 	enc := newTestEncryptonize(t)

--- a/encryptonize_test.go
+++ b/encryptonize_test.go
@@ -486,7 +486,6 @@ func TestDeleteNonExisting(t *testing.T) {
 // 1) Sealed Access
 // 2) Sealed Object
 func TestDeleteFailureAndRetry(t *testing.T) {
-
 	type testData struct {
 		description string
 		dataType    io.DataType

--- a/encryptonize_test.go
+++ b/encryptonize_test.go
@@ -36,7 +36,8 @@ func newTestEncryptonize(t *testing.T) Encryptonize {
 		TEK: []byte{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2},
 		IEK: []byte{3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3},
 	})
-	ioProvider := io.NewMem()
+	mem := io.NewMem()
+	ioProvider := io.NewProxy(&mem)
 	idProvider, err := id.NewStandalone(
 		id.StandaloneConfig{
 			UEK: []byte{4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4},

--- a/encryptonize_test.go
+++ b/encryptonize_test.go
@@ -467,6 +467,19 @@ func TestDeleteTwice(t *testing.T) {
 	}
 }
 
+// It is verified that no errors are returned when deleting an object that doesn't exist.
+func TestDeleteNonExisting(t *testing.T) {
+	enc := newTestEncryptonize(t)
+	_, token := newTestUser(t, &enc, id.ScopeEncrypt, id.ScopeDecrypt, id.ScopeDelete)
+
+	id := uuid.Must(uuid.NewV4())
+
+	err := enc.Delete(token, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 // It is verified that an unauthenticated user is not able to delete.
 func TestDeleteUnauthenticated(t *testing.T) {
 	enc := newTestEncryptonize(t)

--- a/encryptonize_test.go
+++ b/encryptonize_test.go
@@ -621,17 +621,6 @@ func TestDeleteWrongGroupScope(t *testing.T) {
 	}
 }
 
-// Test that an appropriate error is returned when a user tries to delete an object that does not exist.
-func TestDeleteNotFound(t *testing.T) {
-	enc := newTestEncryptonize(t)
-	_, token := newTestUser(t, &enc, id.ScopeDelete)
-
-	err := enc.Delete(token, uuid.Must(uuid.NewV4()))
-	if !errors.Is(err, io.ErrNotFound) {
-		t.Fatalf("Expected error '%s' but got '%s'", io.ErrNotFound, err)
-	}
-}
-
 ////////////////////////////////////////////////////////
 //            CreateToken/GetTokenContents            //
 ////////////////////////////////////////////////////////

--- a/io/proxy.go
+++ b/io/proxy.go
@@ -1,0 +1,47 @@
+// Copyright 2020-2022 CYBERCRYPT
+
+package io
+
+import (
+	"github.com/gofrs/uuid"
+)
+
+// Proxy is an IO Provider that wraps other IO Providers
+// By default, it forwards calls directly to the implementation,
+// but allows you to customize the behavior as you see fit by
+// changing the individual functions as you see fit.
+type Proxy struct {
+	Implementation Provider
+	PutFunc        func(id uuid.UUID, dataType DataType, data []byte) error
+	GetFunc        func(id uuid.UUID, dataType DataType) ([]byte, error)
+	UpdateFunc     func(id uuid.UUID, dataType DataType, data []byte) error
+	DeleteFunc     func(id uuid.UUID, dataType DataType) error
+}
+
+func (o *Proxy) Put(id uuid.UUID, dataType DataType, data []byte) error {
+	return o.PutFunc(id, dataType, data)
+}
+
+func (o *Proxy) Get(id uuid.UUID, dataType DataType) ([]byte, error) {
+	return o.GetFunc(id, dataType)
+}
+
+func (o *Proxy) Update(id uuid.UUID, dataType DataType, data []byte) error {
+	return o.UpdateFunc(id, dataType, data)
+}
+
+func (o *Proxy) Delete(id uuid.UUID, dataType DataType) error {
+	return o.DeleteFunc(id, dataType)
+}
+
+// NewProxy returns a basic implementation of Proxy that can be used as a basis
+// for tests.
+func NewProxy(implementation Provider) Proxy {
+	return Proxy{
+		Implementation: implementation,
+		PutFunc:        implementation.Put,
+		GetFunc:        implementation.Get,
+		UpdateFunc:     implementation.Update,
+		DeleteFunc:     implementation.Delete,
+	}
+}


### PR DESCRIPTION
### Description

This PR contains some adjustments to how deletes are handled in the lib:
- No errors are returned when you attempt to delete something that already doesn't exist.
- Sealed access is now deleted _after_ sealed objects, to avoid dangling objects in cases where the deletion of access succeeded but the deletion of the sealed object failed. Instead, we accept a dangling sealed access with no object, which can be cleaned up by calling delete again.

### Relevant Issues/PRs

Supports ongoing work in d1-service-storage, related to DEV-181.

### Type(s) of Change (Split the PR if you check many)

- [ ] Added user feature
- [ ] Added technical feature
- [x] Added tests
- [x] Refactor
- [ ] Bugfix
- [ ] Updated documentation
- [ ] Kubernetes changes
- [ ] CI/CD workflow changes

### Testing Checklist

- [x] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist

- [x] I have pulled in the latest changes from master.
- [x] I have run `make lint`.
- [x] I have successfully run `make tests`.
- [ ] I have updated relevant CI/CD workflows.
- [ ] I have updated relevant Kubernetes manifests/scripts.
- [ ] I have updated/added relevant (internal and external) documentation (readme, doc comments, etc).
- [ ] I have updated the dependency map to reflect my changes.
- [ ] I have added the license to new source code files.
- [x] I have spent some time looking over the full diff before creating this PR.

### Technical Debt

None.
