### PR TITLE
Change IO datatype sealedID to sealedIdentifier.

### DIFF
--- a/index/index.go
+++ b/index/index.go
@@ -325,7 +325,7 @@ func (i *SecureIndex) putSealedIdentifier(tag []byte, sealedID *data.SealedIdent
 		return err
 	}
 
-	return i.ioProvider.Put(label, io.DataTypeSealedID, sealedIDBuffer.Bytes())
+	return i.ioProvider.Put(label, io.DataTypeSealedIdentifier, sealedIDBuffer.Bytes())
 }
 
 // updateSealedIdentifier encodes an updated sealed Identifier and updates it in the IO Provider.
@@ -341,7 +341,7 @@ func (i *SecureIndex) updateSealedIdentifier(tag []byte, sealedID *data.SealedId
 		return err
 	}
 
-	return i.ioProvider.Update(label, io.DataTypeSealedID, sealedIDBuffer.Bytes())
+	return i.ioProvider.Update(label, io.DataTypeSealedIdentifier, sealedIDBuffer.Bytes())
 }
 
 // getSealedIdentifier fetches bytes from the IO Provider and decodes them into a sealed Identifier.
@@ -351,7 +351,7 @@ func (i *SecureIndex) getSealedIdentifier(tag []byte) (*data.SealedIdentifier, e
 		return nil, err
 	}
 
-	sealedIDBytes, err := i.ioProvider.Get(label, io.DataTypeSealedID)
+	sealedIDBytes, err := i.ioProvider.Get(label, io.DataTypeSealedIdentifier)
 	if err != nil {
 		return nil, err
 	}
@@ -373,7 +373,7 @@ func (i *SecureIndex) deleteSealedIdentifier(tag []byte) error {
 		return err
 	}
 
-	return i.ioProvider.Delete(label, io.DataTypeSealedID)
+	return i.ioProvider.Delete(label, io.DataTypeSealedIdentifier)
 }
 
 ////////////////////////////////////////////////////////

--- a/io/io.go
+++ b/io/io.go
@@ -37,7 +37,7 @@ type DataType uint16
 const (
 	DataTypeSealedObject DataType = iota
 	DataTypeSealedAccess
-	DataTypeSealedID
+	DataTypeSealedIdentifier
 	DataTypeEnd
 )
 


### PR DESCRIPTION
### Description

The IO data type "sealedID" has been changed to "sealedIdentifier" to match the naming in index.

### Type(s) of Change (Split the PR if you check many)

- [ ] Added user feature
- [ ] Added technical feature
- [ ] Added tests
- [ ] Refactor
- [x] Bugfix
- [ ] Updated documentation
- [ ] Kubernetes changes
- [ ] CI/CD workflow changes

### Testing Checklist

- [ ] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist

- [ ] I have pulled in the latest changes from master.
- [x] I have run `make lint`.
- [x] I have successfully run `make tests`.
- [ ] I have updated relevant CI/CD workflows.
- [ ] I have updated relevant Kubernetes manifests/scripts.
- [ ] I have updated/added relevant (internal and external) documentation (readme, doc comments, etc).
- [ ] I have updated the dependency map to reflect my changes.
- [ ] I have added the license to new source code files.
- [ ] I have spent some time looking over the full diff before creating this PR.
