### PR TITLE
IO provider bytes

### DIFF
--- a/d1_test.go
+++ b/d1_test.go
@@ -396,7 +396,7 @@ func TestUpdateNotFound(t *testing.T) {
 //                       Delete                       //
 ////////////////////////////////////////////////////////
 
-func checkDataIsDeleted(t *testing.T, ioProvider io.Provider, id uuid.UUID, dataTypes ...io.DataType) {
+func checkDataIsDeleted(t *testing.T, ioProvider io.Provider, id []byte, dataTypes ...io.DataType) {
 	for _, dataType := range dataTypes {
 		sealedData, err := ioProvider.Get(id, dataType)
 		if !errors.Is(err, io.ErrNotFound) {
@@ -436,7 +436,7 @@ func TestDelete(t *testing.T) {
 	}
 
 	// Double-check with the IO Provider that the sealed data is gone.
-	checkDataIsDeleted(t, enc.ioProvider, id,
+	checkDataIsDeleted(t, enc.ioProvider, id.Bytes(),
 		io.DataTypeSealedAccess,
 		io.DataTypeSealedObject,
 	)
@@ -524,7 +524,7 @@ func TestDeleteFailureAndRetry(t *testing.T) {
 
 			// Temporarily inject failures into the delete function.
 			delete := ioProxy.DeleteFunc
-			ioProxy.DeleteFunc = func(id uuid.UUID, dataType io.DataType) error {
+			ioProxy.DeleteFunc = func(id []byte, dataType io.DataType) error {
 				if dataType == test.dataType {
 					return test.err
 				}
@@ -537,7 +537,7 @@ func TestDeleteFailureAndRetry(t *testing.T) {
 
 			// Double-check with the IO Provider that the sealed access/object is still there.
 			// NOTE: We don't check the other sealed entries, since they may or may not be gone at this point.
-			_, err = enc.ioProvider.Get(id, test.dataType)
+			_, err = enc.ioProvider.Get(id.Bytes(), test.dataType)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -550,7 +550,7 @@ func TestDeleteFailureAndRetry(t *testing.T) {
 			}
 
 			// Double-check with the IO Provider that the sealed data is gone.
-			checkDataIsDeleted(t, enc.ioProvider, id,
+			checkDataIsDeleted(t, enc.ioProvider, id.Bytes(),
 				io.DataTypeSealedAccess,
 				io.DataTypeSealedObject,
 			)

--- a/id/standalone.go
+++ b/id/standalone.go
@@ -244,7 +244,7 @@ func (s *Standalone) DeleteUser(token string, uid uuid.UUID) error {
 		return err
 	}
 
-	return s.ioProvider.Delete(uid, DataTypeSealedUser)
+	return s.ioProvider.Delete(uid.Bytes(), DataTypeSealedUser)
 }
 
 // NewGroup creates a new group and adds the calling user to it.
@@ -293,14 +293,14 @@ func (s *Standalone) putUser(uid uuid.UUID, user *User, update bool) error {
 	}
 
 	if update {
-		return s.ioProvider.Update(sealedUser.UID, DataTypeSealedUser, userBuffer.Bytes())
+		return s.ioProvider.Update(sealedUser.UID.Bytes(), DataTypeSealedUser, userBuffer.Bytes())
 	}
-	return s.ioProvider.Put(sealedUser.UID, DataTypeSealedUser, userBuffer.Bytes())
+	return s.ioProvider.Put(sealedUser.UID.Bytes(), DataTypeSealedUser, userBuffer.Bytes())
 }
 
 // getUser fetches bytes from the IO Provider, decodes them into a sealed user, and unseals it.
 func (s *Standalone) getUser(uid uuid.UUID) (*User, error) {
-	userBytes, err := s.ioProvider.Get(uid, DataTypeSealedUser)
+	userBytes, err := s.ioProvider.Get(uid.Bytes(), DataTypeSealedUser)
 	if err != nil {
 		return nil, err
 	}
@@ -334,12 +334,12 @@ func (s *Standalone) putGroup(gid uuid.UUID, group *Group) error {
 		return err
 	}
 
-	return s.ioProvider.Put(sealedGroup.GID, DataTypeSealedGroup, groupBuffer.Bytes())
+	return s.ioProvider.Put(sealedGroup.GID.Bytes(), DataTypeSealedGroup, groupBuffer.Bytes())
 }
 
 // getGroup fetches bytes from the IO Provider, decodes them into a sealed group, and unseals it.
 func (s *Standalone) getGroup(gid uuid.UUID) (*Group, error) {
-	groupBytes, err := s.ioProvider.Get(gid, DataTypeSealedGroup)
+	groupBytes, err := s.ioProvider.Get(gid.Bytes(), DataTypeSealedGroup)
 	if err != nil {
 		return nil, err
 	}

--- a/id/standalone_test.go
+++ b/id/standalone_test.go
@@ -43,13 +43,13 @@ func newTestStandalone(t *testing.T) *Standalone {
 }
 
 func manipulateUser(t *testing.T, uid uuid.UUID, standalone *Standalone) {
-	userBytes, err := standalone.ioProvider.Get(uid, DataTypeSealedUser)
+	userBytes, err := standalone.ioProvider.Get(uid.Bytes(), DataTypeSealedUser)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	copy(userBytes[:5], make([]byte, 5))
-	if err := standalone.ioProvider.Update(uid, DataTypeSealedUser, userBytes); err != nil {
+	if err := standalone.ioProvider.Update(uid.Bytes(), DataTypeSealedUser, userBytes); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/index/index.go
+++ b/index/index.go
@@ -17,13 +17,9 @@ package index
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/gob"
 	"errors"
 	"fmt"
-
-	"github.com/gofrs/uuid"
-	"golang.org/x/crypto/sha3"
 
 	"github.com/cybercryptio/d1-lib/crypto"
 	"github.com/cybercryptio/d1-lib/data"
@@ -320,12 +316,7 @@ func (i *SecureIndex) putSealedIdentifier(tag []byte, sealedID *data.SealedIdent
 		return err
 	}
 
-	label, err := computeLabelUUID(tag)
-	if err != nil {
-		return err
-	}
-
-	return i.ioProvider.Put(label, io.DataTypeSealedIdentifier, sealedIDBuffer.Bytes())
+	return i.ioProvider.Put(tag, io.DataTypeSealedIdentifier, sealedIDBuffer.Bytes())
 }
 
 // updateSealedIdentifier encodes an updated sealed Identifier and updates it in the IO Provider.
@@ -336,22 +327,12 @@ func (i *SecureIndex) updateSealedIdentifier(tag []byte, sealedID *data.SealedId
 		return err
 	}
 
-	label, err := computeLabelUUID(tag)
-	if err != nil {
-		return err
-	}
-
-	return i.ioProvider.Update(label, io.DataTypeSealedIdentifier, sealedIDBuffer.Bytes())
+	return i.ioProvider.Update(tag, io.DataTypeSealedIdentifier, sealedIDBuffer.Bytes())
 }
 
 // getSealedIdentifier fetches bytes from the IO Provider and decodes them into a sealed Identifier.
 func (i *SecureIndex) getSealedIdentifier(tag []byte) (*data.SealedIdentifier, error) {
-	label, err := computeLabelUUID(tag)
-	if err != nil {
-		return nil, err
-	}
-
-	sealedIDBytes, err := i.ioProvider.Get(label, io.DataTypeSealedIdentifier)
+	sealedIDBytes, err := i.ioProvider.Get(tag, io.DataTypeSealedIdentifier)
 	if err != nil {
 		return nil, err
 	}
@@ -368,30 +349,5 @@ func (i *SecureIndex) getSealedIdentifier(tag []byte) (*data.SealedIdentifier, e
 
 // deleteSealedIdentifier deletes a sealed Identifier from the IO Provider.
 func (i *SecureIndex) deleteSealedIdentifier(tag []byte) error {
-	label, err := computeLabelUUID(tag)
-	if err != nil {
-		return err
-	}
-
-	return i.ioProvider.Delete(label, io.DataTypeSealedIdentifier)
-}
-
-////////////////////////////////////////////////////////
-//                    Conversions                     //
-////////////////////////////////////////////////////////
-
-// computeLabelUUID converts the label given as input to a uuid.
-func computeLabelUUID(label []byte) (uuid.UUID, error) {
-	// THIS BASEUUID IS PART OF A TEMPORARY SOLUTION AND SHOULD BE DELETED IN AN UPDATED VERSION.
-	baseUUID, _ := uuid.FromString("f939afb8-e5fb-47b5-a7b5-784d41252359")
-
-	// Convert label to a uuid.
-	return uuidFromString(baseUUID, base64.StdEncoding.EncodeToString(label)), nil
-}
-
-// uuidFromString uses a V5 UUID to get a deterministic ID based on the input.
-func uuidFromString(base uuid.UUID, input string) uuid.UUID {
-	// We use SHA3 here to avoid any issues with SHA1 which is used in `uuid.NewV5`.
-	subjHash := sha3.Sum512([]byte(input))
-	return uuid.NewV5(base, string(subjHash[:]))
+	return i.ioProvider.Delete(tag, io.DataTypeSealedIdentifier)
 }

--- a/io/bolt.go
+++ b/io/bolt.go
@@ -18,7 +18,6 @@ package io
 import (
 	"time"
 
-	"github.com/gofrs/uuid"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -52,8 +51,8 @@ func NewBolt(path string) (Bolt, error) {
 	return Bolt{store, objectBucket}, nil
 }
 
-func (b *Bolt) Put(id uuid.UUID, dataType DataType, data []byte) error {
-	key := append(id.Bytes(), dataType.Bytes()...)
+func (b *Bolt) Put(id []byte, dataType DataType, data []byte) error {
+	key := append(id, dataType.Bytes()...)
 	return b.store.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(b.objectBucket)
 		if b.Get(key) != nil {
@@ -63,8 +62,8 @@ func (b *Bolt) Put(id uuid.UUID, dataType DataType, data []byte) error {
 	})
 }
 
-func (b *Bolt) Get(id uuid.UUID, dataType DataType) ([]byte, error) {
-	key := append(id.Bytes(), dataType.Bytes()...)
+func (b *Bolt) Get(id []byte, dataType DataType) ([]byte, error) {
+	key := append(id, dataType.Bytes()...)
 	var out []byte
 	err := b.store.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket(b.objectBucket)
@@ -80,8 +79,8 @@ func (b *Bolt) Get(id uuid.UUID, dataType DataType) ([]byte, error) {
 	return out, nil
 }
 
-func (b *Bolt) Update(id uuid.UUID, dataType DataType, data []byte) error {
-	key := append(id.Bytes(), dataType.Bytes()...)
+func (b *Bolt) Update(id []byte, dataType DataType, data []byte) error {
+	key := append(id, dataType.Bytes()...)
 	return b.store.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(b.objectBucket)
 		if b.Get(key) == nil {
@@ -91,8 +90,8 @@ func (b *Bolt) Update(id uuid.UUID, dataType DataType, data []byte) error {
 	})
 }
 
-func (b *Bolt) Delete(id uuid.UUID, dataType DataType) error {
-	key := append(id.Bytes(), dataType.Bytes()...)
+func (b *Bolt) Delete(id []byte, dataType DataType) error {
+	key := append(id, dataType.Bytes()...)
 	return b.store.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(b.objectBucket)
 		return b.Delete(key)

--- a/io/bolt_test.go
+++ b/io/bolt_test.go
@@ -20,8 +20,6 @@ import (
 
 	"bytes"
 	"errors"
-
-	"github.com/gofrs/uuid"
 )
 
 // Test that putting and subsequently getting data returns the right bytes for all data types.
@@ -32,7 +30,7 @@ func TestBoltPutAndGet(t *testing.T) {
 	}
 
 	data := []byte("mock data")
-	id := uuid.Must(uuid.NewV4())
+	id := []byte("mock id")
 
 	for dt := DataType(0); dt < DataTypeEnd; dt++ {
 		testData := append(data, dt.Bytes()...)
@@ -60,7 +58,7 @@ func TestBoltPutAlreadyExists(t *testing.T) {
 	}
 
 	data := []byte("mock data")
-	id := uuid.Must(uuid.NewV4())
+	id := []byte("mock id")
 
 	for dt := DataType(0); dt < DataTypeEnd; dt++ {
 		testData := append(data, dt.Bytes()...)
@@ -83,7 +81,7 @@ func TestBoltNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	id := uuid.Must(uuid.NewV4())
+	id := []byte("mock id")
 
 	data, err := bolt.Get(id, DataTypeSealedObject)
 	if !errors.Is(err, ErrNotFound) {
@@ -111,7 +109,7 @@ func TestBoltUpdate(t *testing.T) {
 
 	data := []byte("mock data")
 	updated := []byte("updated mock data")
-	id := uuid.Must(uuid.NewV4())
+	id := []byte("mock id")
 
 	for dt := DataType(0); dt < DataTypeEnd; dt++ {
 		err := bolt.Put(id, dt, append(data, dt.Bytes()...))
@@ -143,7 +141,7 @@ func TestBoltUpdateNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	id := uuid.Must(uuid.NewV4())
+	id := []byte("mock id")
 
 	err = bolt.Update(id, DataTypeSealedObject, []byte("mock data"))
 	if !errors.Is(err, ErrNotFound) {
@@ -159,7 +157,7 @@ func TestBoltDelete(t *testing.T) {
 	}
 
 	data := []byte("mock data")
-	id := uuid.Must(uuid.NewV4())
+	id := []byte("mock id")
 
 	for dt := DataType(0); dt < DataTypeEnd; dt++ {
 		err := bolt.Put(id, dt, append(data, dt.Bytes()...))
@@ -189,7 +187,7 @@ func TestBoltDeleteNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	id := uuid.Must(uuid.NewV4())
+	id := []byte("mock id")
 
 	err = bolt.Delete(id, DataTypeSealedObject)
 	if err != nil {

--- a/io/io.go
+++ b/io/io.go
@@ -21,8 +21,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-
-	"github.com/gofrs/uuid"
 )
 
 // Error returned if data is not found during a "Get" or "Update" call.
@@ -41,7 +39,7 @@ const (
 	DataTypeEnd
 )
 
-// Bytes returns a byte representation of a DataType..
+// Bytes returns a byte representation of a DataType.
 func (d DataType) Bytes() []byte {
 	b := make([]byte, binary.MaxVarintLen16)
 	binary.LittleEndian.PutUint16(b, uint16(d))
@@ -57,15 +55,15 @@ func (d DataType) String() string {
 type Provider interface {
 	// Put sends bytes to the IO Provider. The data is identified by an ID and a data type.
 	// Should error if the data already exists in the IO Provider.
-	Put(id uuid.UUID, dataType DataType, data []byte) error
+	Put(id []byte, dataType DataType, data []byte) error
 
 	// Get fetches data from the IO Provider. The data is identified by an ID and a data type.
-	Get(id uuid.UUID, dataType DataType) ([]byte, error)
+	Get(id []byte, dataType DataType) ([]byte, error)
 
 	// Update is similar to Put but updates data previously sent to the IO Provider.
 	// Should error if the data does not exist in the IO Provider.
-	Update(id uuid.UUID, dataType DataType, data []byte) error
+	Update(id []byte, dataType DataType, data []byte) error
 
 	// Delete removes data previously sent to the IO Provider.
-	Delete(id uuid.UUID, dataType DataType) error
+	Delete(id []byte, dataType DataType) error
 }

--- a/io/mem.go
+++ b/io/mem.go
@@ -18,8 +18,6 @@ package io
 import (
 	"fmt"
 	"sync"
-
-	"github.com/gofrs/uuid"
 )
 
 // Mem implements an in-memory version of an IO Provider.
@@ -32,12 +30,12 @@ func NewMem() Mem {
 	return Mem{sync.Map{}}
 }
 
-func newKey(id uuid.UUID, dataType DataType) string {
-	key := fmt.Sprintf("%s:%s", id.String(), dataType.String())
+func newKey(id []byte, dataType DataType) string {
+	key := fmt.Sprintf("%x:%s", id, dataType.String())
 	return key
 }
 
-func (m *Mem) Put(id uuid.UUID, dataType DataType, data []byte) error {
+func (m *Mem) Put(id []byte, dataType DataType, data []byte) error {
 	key := newKey(id, dataType)
 	if _, ok := m.data.Load(key); ok {
 		return ErrAlreadyExists
@@ -46,7 +44,7 @@ func (m *Mem) Put(id uuid.UUID, dataType DataType, data []byte) error {
 	return nil
 }
 
-func (m *Mem) Get(id uuid.UUID, dataType DataType) ([]byte, error) {
+func (m *Mem) Get(id []byte, dataType DataType) ([]byte, error) {
 	key := newKey(id, dataType)
 	out, ok := m.data.Load(key)
 	if !ok {
@@ -56,7 +54,7 @@ func (m *Mem) Get(id uuid.UUID, dataType DataType) ([]byte, error) {
 	return data, nil
 }
 
-func (m *Mem) Update(id uuid.UUID, dataType DataType, data []byte) error {
+func (m *Mem) Update(id []byte, dataType DataType, data []byte) error {
 	key := newKey(id, dataType)
 	if _, ok := m.data.Load(key); !ok {
 		return ErrNotFound
@@ -65,7 +63,7 @@ func (m *Mem) Update(id uuid.UUID, dataType DataType, data []byte) error {
 	return nil
 }
 
-func (m *Mem) Delete(id uuid.UUID, dataType DataType) error {
+func (m *Mem) Delete(id []byte, dataType DataType) error {
 	key := newKey(id, dataType)
 	m.data.Delete(key)
 	return nil

--- a/io/mem_test.go
+++ b/io/mem_test.go
@@ -20,8 +20,6 @@ import (
 
 	"bytes"
 	"errors"
-
-	"github.com/gofrs/uuid"
 )
 
 // Test that putting and subsequently getting data returns the right bytes for all data types.
@@ -29,7 +27,7 @@ func TestMemPutAndGet(t *testing.T) {
 	mem := NewMem()
 
 	data := []byte("mock data")
-	id := uuid.Must(uuid.NewV4())
+	id := []byte("mock id")
 
 	for dt := DataType(0); dt < DataTypeEnd; dt++ {
 		testData := append(data, dt.Bytes()...)
@@ -54,7 +52,7 @@ func TestMemPutAlreadyExists(t *testing.T) {
 	mem := NewMem()
 
 	data := []byte("mock data")
-	id := uuid.Must(uuid.NewV4())
+	id := []byte("mock id")
 
 	for dt := DataType(0); dt < DataTypeEnd; dt++ {
 		testData := append(data, dt.Bytes()...)
@@ -74,7 +72,7 @@ func TestMemPutAlreadyExists(t *testing.T) {
 func TestMemNotFound(t *testing.T) {
 	mem := NewMem()
 
-	id := uuid.Must(uuid.NewV4())
+	id := []byte("mock id")
 
 	data, err := mem.Get(id, DataTypeSealedObject)
 	if !errors.Is(err, ErrNotFound) {
@@ -91,7 +89,7 @@ func TestMemUpdate(t *testing.T) {
 
 	data := []byte("mock data")
 	updated := []byte("updated mock data")
-	id := uuid.Must(uuid.NewV4())
+	id := []byte("mock id")
 
 	for dt := DataType(0); dt < DataTypeEnd; dt++ {
 		err := mem.Put(id, dt, append(data, dt.Bytes()...))
@@ -120,7 +118,7 @@ func TestMemUpdate(t *testing.T) {
 func TestMemUpdateNotFound(t *testing.T) {
 	mem := NewMem()
 
-	id := uuid.Must(uuid.NewV4())
+	id := []byte("mock id")
 
 	err := mem.Update(id, DataTypeSealedObject, []byte("mock data"))
 	if !errors.Is(err, ErrNotFound) {
@@ -133,7 +131,7 @@ func TestMemDelete(t *testing.T) {
 	mem := NewMem()
 
 	data := []byte("mock data")
-	id := uuid.Must(uuid.NewV4())
+	id := []byte("mock id")
 
 	for dt := DataType(0); dt < DataTypeEnd; dt++ {
 		err := mem.Put(id, dt, append(data, dt.Bytes()...))
@@ -160,7 +158,7 @@ func TestMemDelete(t *testing.T) {
 func TestMemDeleteNotFound(t *testing.T) {
 	mem := NewMem()
 
-	id := uuid.Must(uuid.NewV4())
+	id := []byte("mock id")
 
 	err := mem.Delete(id, DataTypeSealedObject)
 	if err != nil {

--- a/io/proxy.go
+++ b/io/proxy.go
@@ -2,35 +2,31 @@
 
 package io
 
-import (
-	"github.com/gofrs/uuid"
-)
-
 // Proxy is an IO Provider that wraps other IO Providers
 // By default, it forwards calls directly to the implementation,
 // but allows you to customize the behavior as you see fit by
 // changing the individual functions as you see fit.
 type Proxy struct {
 	Implementation Provider
-	PutFunc        func(id uuid.UUID, dataType DataType, data []byte) error
-	GetFunc        func(id uuid.UUID, dataType DataType) ([]byte, error)
-	UpdateFunc     func(id uuid.UUID, dataType DataType, data []byte) error
-	DeleteFunc     func(id uuid.UUID, dataType DataType) error
+	PutFunc        func(id []byte, dataType DataType, data []byte) error
+	GetFunc        func(id []byte, dataType DataType) ([]byte, error)
+	UpdateFunc     func(id []byte, dataType DataType, data []byte) error
+	DeleteFunc     func(id []byte, dataType DataType) error
 }
 
-func (o *Proxy) Put(id uuid.UUID, dataType DataType, data []byte) error {
+func (o *Proxy) Put(id []byte, dataType DataType, data []byte) error {
 	return o.PutFunc(id, dataType, data)
 }
 
-func (o *Proxy) Get(id uuid.UUID, dataType DataType) ([]byte, error) {
+func (o *Proxy) Get(id []byte, dataType DataType) ([]byte, error) {
 	return o.GetFunc(id, dataType)
 }
 
-func (o *Proxy) Update(id uuid.UUID, dataType DataType, data []byte) error {
+func (o *Proxy) Update(id []byte, dataType DataType, data []byte) error {
 	return o.UpdateFunc(id, dataType, data)
 }
 
-func (o *Proxy) Delete(id uuid.UUID, dataType DataType) error {
+func (o *Proxy) Delete(id []byte, dataType DataType) error {
 	return o.DeleteFunc(id, dataType)
 }
 

--- a/utility.go
+++ b/utility.go
@@ -58,14 +58,14 @@ func (d *D1) putSealedObject(object *data.SealedObject, update bool) error {
 	}
 
 	if update {
-		return d.ioProvider.Update(object.OID, io.DataTypeSealedObject, objectBuffer.Bytes())
+		return d.ioProvider.Update(object.OID.Bytes(), io.DataTypeSealedObject, objectBuffer.Bytes())
 	}
-	return d.ioProvider.Put(object.OID, io.DataTypeSealedObject, objectBuffer.Bytes())
+	return d.ioProvider.Put(object.OID.Bytes(), io.DataTypeSealedObject, objectBuffer.Bytes())
 }
 
 // getSealedObject fetches bytes from the IO Provider and decodes them into a sealed object.
 func (d *D1) getSealedObject(oid uuid.UUID) (*data.SealedObject, error) {
-	objectBytes, err := d.ioProvider.Get(oid, io.DataTypeSealedObject)
+	objectBytes, err := d.ioProvider.Get(oid.Bytes(), io.DataTypeSealedObject)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func (d *D1) getSealedObject(oid uuid.UUID) (*data.SealedObject, error) {
 
 // deleteSealedObject deletes a sealed object from the IO Provider.
 func (d *D1) deleteSealedObject(oid uuid.UUID) error {
-	return d.ioProvider.Delete(oid, io.DataTypeSealedObject)
+	return d.ioProvider.Delete(oid.Bytes(), io.DataTypeSealedObject)
 }
 
 // putSealedAccess encodes a sealed access and sends it to the IO Provider, either as a "Put" or an
@@ -96,14 +96,14 @@ func (d *D1) putSealedAccess(access *data.SealedAccess, update bool) error {
 	}
 
 	if update {
-		return d.ioProvider.Update(access.OID, io.DataTypeSealedAccess, accessBuffer.Bytes())
+		return d.ioProvider.Update(access.OID.Bytes(), io.DataTypeSealedAccess, accessBuffer.Bytes())
 	}
-	return d.ioProvider.Put(access.OID, io.DataTypeSealedAccess, accessBuffer.Bytes())
+	return d.ioProvider.Put(access.OID.Bytes(), io.DataTypeSealedAccess, accessBuffer.Bytes())
 }
 
 // getSealedAccess fetches bytes from the IO Provider and decodes them into a sealed access.
 func (d *D1) getSealedAccess(oid uuid.UUID) (*data.SealedAccess, error) {
-	accessBytes, err := d.ioProvider.Get(oid, io.DataTypeSealedAccess)
+	accessBytes, err := d.ioProvider.Get(oid.Bytes(), io.DataTypeSealedAccess)
 	if err != nil {
 		return nil, err
 	}
@@ -121,5 +121,5 @@ func (d *D1) getSealedAccess(oid uuid.UUID) (*data.SealedAccess, error) {
 
 // deleteSealedAccess deletes a sealed object from the IO Provider.
 func (d *D1) deleteSealedAccess(oid uuid.UUID) error {
-	return d.ioProvider.Delete(oid, io.DataTypeSealedAccess)
+	return d.ioProvider.Delete(oid.Bytes(), io.DataTypeSealedAccess)
 }


### PR DESCRIPTION
### Description
While doing the Secure Index implementation we discovered that the current IO provider interface is a bit too inflexible with regards to the data type of data IDs. In particular we needed an id of size 256 bit, but a UUID is only 128 bit.

This PR changes the IO provider interface to take a byte slice as ID instead of a UUID. 

### Relevant Issues/PRs
Closes DEV-300

### Type(s) of Change (Split the PR if you check many)

- [ ] Added user feature
- [ ] Added technical feature
- [ ] Added tests
- [x] Refactor
- [ ] Bugfix
- [ ] Updated documentation
- [ ] Kubernetes changes
- [ ] CI/CD workflow changes

### Testing Checklist

- [x] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist

- [x] I have pulled in the latest changes from master.
- [x] I have run `make lint`.
- [x] I have successfully run `make tests`.
- [ ] I have updated relevant CI/CD workflows.
- [ ] I have updated relevant Kubernetes manifests/scripts.
- [ ] I have updated/added relevant (internal and external) documentation (readme, doc comments, etc).
- [ ] I have updated the dependency map to reflect my changes.
- [ ] I have added the license to new source code files.
- [x] I have spent some time looking over the full diff before creating this PR.
