### PR TITLE
String access

### DIFF
--- a/d1.go
+++ b/d1.go
@@ -307,7 +307,7 @@ func (d *D1) GetTokenContents(token *data.SealedToken) ([]byte, error) {
 //
 // Required scopes:
 // - GetAccessGroups
-func (d *D1) GetAccessGroups(token string, oid uuid.UUID) (map[uuid.UUID]struct{}, error) {
+func (d *D1) GetAccessGroups(token string, oid uuid.UUID) (map[string]struct{}, error) {
 	identity, err := d.idProvider.GetIdentity(token)
 	if err != nil {
 		return nil, ErrNotAuthenticated
@@ -336,7 +336,7 @@ func (d *D1) GetAccessGroups(token string, oid uuid.UUID) (map[uuid.UUID]struct{
 //
 // Required scopes:
 // - ModifyAccessGroups
-func (d *D1) AddGroupsToAccess(token string, oid uuid.UUID, groups ...uuid.UUID) error {
+func (d *D1) AddGroupsToAccess(token string, oid uuid.UUID, groups ...string) error {
 	identity, err := d.idProvider.GetIdentity(token)
 	if err != nil {
 		return ErrNotAuthenticated
@@ -371,7 +371,7 @@ func (d *D1) AddGroupsToAccess(token string, oid uuid.UUID, groups ...uuid.UUID)
 //
 // Required scopes:
 // - ModifyAccessGroups
-func (d *D1) RemoveGroupsFromAccess(token string, oid uuid.UUID, groups ...uuid.UUID) error {
+func (d *D1) RemoveGroupsFromAccess(token string, oid uuid.UUID, groups ...string) error {
 	identity, err := d.idProvider.GetIdentity(token)
 	if err != nil {
 		return ErrNotAuthenticated

--- a/data/access.go
+++ b/data/access.go
@@ -24,8 +24,9 @@ import (
 // Access is used to manage access to encrypted objects. Note: All member fields need to be exported
 // in order for gob to serialize them.
 type Access struct {
-	// The set of groups that have access to the associated object.
-	Groups map[uuid.UUID]struct{}
+	// The set of groups that have access to the associated object. The format of the key strings
+	// depends on how the ID Provider implements group identifiers.
+	Groups map[string]struct{}
 
 	// The wrapped encryption key for the associated object.
 	WrappedOEK []byte
@@ -43,7 +44,7 @@ type SealedAccess struct {
 // NewAccess creates a new access object which contains the provided wrapped key and no groups.
 func NewAccess(wrappedOEK []byte) Access {
 	return Access{
-		Groups:     map[uuid.UUID]struct{}{},
+		Groups:     map[string]struct{}{},
 		WrappedOEK: wrappedOEK,
 	}
 }
@@ -65,14 +66,14 @@ func (a *Access) Seal(oid uuid.UUID, cryptor crypto.CryptorInterface) (SealedAcc
 }
 
 // AddGroups appends the provided group IDs to the access object.
-func (a *Access) AddGroups(ids ...uuid.UUID) {
+func (a *Access) AddGroups(ids ...string) {
 	for _, id := range ids {
 		a.Groups[id] = struct{}{}
 	}
 }
 
 // RemoveGroups removes the provided group IDs from the access object.
-func (a *Access) RemoveGroups(ids ...uuid.UUID) {
+func (a *Access) RemoveGroups(ids ...string) {
 	for _, id := range ids {
 		delete(a.Groups, id)
 	}
@@ -80,7 +81,7 @@ func (a *Access) RemoveGroups(ids ...uuid.UUID) {
 
 // ContainsGroups returns true if all provided group IDs are contained in the access object, and
 // false otherwise.
-func (a *Access) ContainsGroups(ids ...uuid.UUID) bool {
+func (a *Access) ContainsGroups(ids ...string) bool {
 	for _, id := range ids {
 		if _, exists := a.Groups[id]; !exists {
 			return false
@@ -90,7 +91,7 @@ func (a *Access) ContainsGroups(ids ...uuid.UUID) bool {
 }
 
 // GetGroups returns the set of group IDs contained in the access object.
-func (a *Access) GetGroups() map[uuid.UUID]struct{} {
+func (a *Access) GetGroups() map[string]struct{} {
 	return a.Groups
 }
 

--- a/data/access_test.go
+++ b/data/access_test.go
@@ -16,6 +16,7 @@
 package data
 
 import (
+	"fmt"
 	"testing"
 
 	"reflect"
@@ -25,41 +26,41 @@ import (
 	"github.com/cybercryptio/d1-lib/crypto"
 )
 
-var accessGroups = []uuid.UUID{
-	uuid.Must(uuid.FromString("10000000-0000-0000-0000-000000000000")),
-	uuid.Must(uuid.FromString("20000000-0000-0000-0000-000000000000")),
-	uuid.Must(uuid.FromString("30000000-0000-0000-0000-000000000000")),
-	uuid.Must(uuid.FromString("40000000-0000-0000-0000-000000000000")),
+var groupIDs = []string{
+	"groupID1",
+	"groupID2",
+	"groupID3",
+	"groupID4",
 }
 
 func TestAccessGetGroupIDs(t *testing.T) {
-	groupID := uuid.Must(uuid.NewV4())
+	groupID := "groupID"
 	access := NewAccess(nil)
 	access.AddGroups(groupID)
 
-	uuids := access.GetGroups()
-	if _, ok := uuids[groupID]; len(uuids) == 0 || !ok {
+	accessGroups := access.GetGroups()
+	if _, ok := accessGroups[groupID]; len(accessGroups) == 0 || !ok {
 		t.Error("Expected GetGroups to return a group ID")
 	}
 }
 
 func TestAccessGetZeroGroupIDs(t *testing.T) {
 	access := NewAccess(nil)
-	uuids := access.GetGroups()
-	if len(uuids) != 0 {
+	accessGroups := access.GetGroups()
+	if len(accessGroups) != 0 {
 		t.Error("GetGroups should have returned empty array")
 	}
 }
 
 func TestAccessContainsGroup(t *testing.T) {
 	access := NewAccess(nil)
-	access.AddGroups(accessGroups...)
+	access.AddGroups(groupIDs...)
 
-	if !access.ContainsGroups(accessGroups...) {
+	if !access.ContainsGroups(groupIDs...) {
 		t.Error("ContainsGroup returned false")
 	}
 
-	if access.ContainsGroups(uuid.Must(uuid.NewV4())) {
+	if access.ContainsGroups("non-existent group ID") {
 		t.Error("ContainsGroup returned true")
 	}
 }
@@ -68,7 +69,7 @@ func TestAccessAdd(t *testing.T) {
 	access := NewAccess(nil)
 
 	for i := 0; i < 256; i++ {
-		g := uuid.Must(uuid.NewV4())
+		g := fmt.Sprintf("groupID%d", i)
 		access.AddGroups(g)
 		if !access.ContainsGroups(g) {
 			t.Error("AddGroup failed")
@@ -78,7 +79,7 @@ func TestAccessAdd(t *testing.T) {
 
 func TestAccessAddDuplicate(t *testing.T) {
 	access := NewAccess(nil)
-	g := uuid.Must(uuid.NewV4())
+	g := "groupID"
 	access.AddGroups(g)
 	access.AddGroups(g)
 	if !access.ContainsGroups(g) {
@@ -88,9 +89,9 @@ func TestAccessAddDuplicate(t *testing.T) {
 
 func TestAccessRemoveGroup(t *testing.T) {
 	access := NewAccess(nil)
-	access.AddGroups(accessGroups...)
+	access.AddGroups(groupIDs...)
 
-	for _, g := range accessGroups {
+	for _, g := range groupIDs {
 		access.RemoveGroups(g)
 		if access.ContainsGroups(g) {
 			t.Error("RemoveGroup failed")
@@ -106,7 +107,7 @@ func TestAccessSeal(t *testing.T) {
 	}
 
 	access := NewAccess(nil)
-	access.AddGroups(accessGroups...)
+	access.AddGroups(groupIDs...)
 
 	id := uuid.Must(uuid.NewV4())
 	sealed, err := access.Seal(id, &cryptor)
@@ -134,7 +135,7 @@ func TestAccessVerifyCiphertext(t *testing.T) {
 	}
 
 	access := NewAccess(nil)
-	access.AddGroups(accessGroups...)
+	access.AddGroups(groupIDs...)
 
 	id := uuid.Must(uuid.NewV4())
 	sealed, err := access.Seal(id, &cryptor)
@@ -159,7 +160,7 @@ func TestAccessVerifyID(t *testing.T) {
 	}
 
 	access := NewAccess(nil)
-	access.AddGroups(accessGroups...)
+	access.AddGroups(groupIDs...)
 
 	id := uuid.Must(uuid.NewV4())
 	sealed, err := access.Seal(id, &cryptor)

--- a/documentation/explainer.md
+++ b/documentation/explainer.md
@@ -25,9 +25,11 @@ The **Identity Provider** is the source of identifying information about the cal
 ### Identity
 
 An **Identity** is an object that contains data about the caller of the library. This data includes:
-- a Universally Unique Identifier (UUID) as defined in the [RFC-4122](https://datatracker.ietf.org/doc/html/rfc4122) standard;
+- a string that uniquely identifies each instance;
 - the [**Scopes**](#scope) of the caller;
 - the **Groups** that the caller belongs to.
+
+The **Identity Provider** implementation must decide the format of the identifying strings for **Identities** and **Groups**, as well as ensure their uniqueness across instances.
 
 ### Scope
 
@@ -47,7 +49,7 @@ The [**Standalone Identity Provider**](https://pkg.go.dev/github.com/cybercrypti
 
 #### User
 
-A **User** is a data structure used by the **Standalone Identity Provider** to store data about the callers of the library. A **User** authenticates to the **Standalone Identity Provider** with a Universally Unique Identifier (UUID) and a password provided upon user creation. A **User** structure contains the salt and hash of the **User's** password, its **Scopes** and a set of **Groups** that the **User** is a member of.
+A **User** is a data structure used by the **Standalone Identity Provider** to store data about the callers of the library. **Users** are uniquely identified using a Universally Unique Identifier (UUID) as defined in the [RFC-4122](https://datatracker.ietf.org/doc/html/rfc4122) standard, and they authenticate to the **Standalone Identity Provider** with their UUID string and a password provided upon user creation. A **User** structure contains the salt and hash of the **User's** password, its **Scopes** and a set of **Groups** that the **User** is a member of.
 
 #### Group
 

--- a/example_access_control_test.go
+++ b/example_access_control_test.go
@@ -19,9 +19,10 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/gofrs/uuid"
+
 	d1lib "github.com/cybercryptio/d1-lib"
 	"github.com/cybercryptio/d1-lib/data"
-	"github.com/gofrs/uuid"
 )
 
 // The UserData struct models the data of a user. It contains both private data that should be kept confidential and public data that can be shared
@@ -37,8 +38,8 @@ type PrivateUserData struct {
 }
 
 type PublicUserData struct {
-	uid uuid.UUID
-	gid uuid.UUID
+	uid string
+	gid string
 	oid uuid.UUID
 }
 

--- a/example_basic_test.go
+++ b/example_basic_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cybercryptio/d1-lib/id"
 	"github.com/cybercryptio/d1-lib/io"
 	"github.com/cybercryptio/d1-lib/key"
-	"github.com/gofrs/uuid"
 )
 
 // These are insecure keys used only for demonstration purposes.
@@ -47,7 +46,7 @@ var idProvider, _ = id.NewStandalone(
 	&ioProvider,
 )
 
-func NewUser() (uuid.UUID, uuid.UUID, string) {
+func NewUser() (string, string, string) {
 	uid, password, err := (&idProvider).NewUser(id.ScopeAll)
 	if err != nil {
 		log.Fatalf("Error creating user: %v", err)

--- a/id/id.go
+++ b/id/id.go
@@ -15,24 +15,24 @@
 
 package id
 
-import (
-	"github.com/gofrs/uuid"
-)
-
+// AccessGroup represents a group of Identities. The Provider implementations should ensure that the
+// ID string is unique across all instances.
 type AccessGroup struct {
-	ID     uuid.UUID
+	ID     string
 	Scopes Scope
 }
 
+// Identity represents data about the caller of the library. The Provider implementations should
+// ensure that the ID string is unique across all instances.
 type Identity struct {
-	ID     uuid.UUID
+	ID     string
 	Scopes Scope
-	Groups map[uuid.UUID]AccessGroup
+	Groups map[string]AccessGroup
 }
 
 // GetIDs returns all IDs related to the identity, i.e. the identity ID and all its group IDs.
-func (i *Identity) GetIDs() map[uuid.UUID]struct{} {
-	ids := make(map[uuid.UUID]struct{}, len(i.Groups)+1)
+func (i *Identity) GetIDs() map[string]struct{} {
+	ids := make(map[string]struct{}, len(i.Groups)+1)
 	ids[i.ID] = struct{}{}
 	for gid := range i.Groups {
 		ids[gid] = struct{}{}
@@ -41,7 +41,7 @@ func (i *Identity) GetIDs() map[uuid.UUID]struct{} {
 }
 
 // GetIDScope returns the scopes associated with a given ID (identity or group ID).
-func (i *Identity) GetIDScope(id uuid.UUID) Scope {
+func (i *Identity) GetIDScope(id string) Scope {
 	if id == i.ID {
 		return i.Scopes
 	}

--- a/id/id_test.go
+++ b/id/id_test.go
@@ -17,18 +17,16 @@ package id
 
 import (
 	"testing"
-
-	"github.com/gofrs/uuid"
 )
 
 func TestGetIDs(t *testing.T) {
-	iid := uuid.Must(uuid.NewV4())
-	gids := []uuid.UUID{uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4()), uuid.Must(uuid.NewV4())}
+	iid := "iid"
+	gids := []string{"gid1", "gid2", "gid3"}
 
 	identity := &Identity{
 		ID:     iid,
 		Scopes: ScopeNone,
-		Groups: map[uuid.UUID]AccessGroup{
+		Groups: map[string]AccessGroup{
 			gids[0]: {gids[0], ScopeNone},
 			gids[1]: {gids[1], ScopeNone},
 			gids[2]: {gids[2], ScopeNone},
@@ -50,13 +48,13 @@ func TestGetIDs(t *testing.T) {
 }
 
 func TestIDScope(t *testing.T) {
-	iid := uuid.Must(uuid.NewV4())
-	gid := uuid.Must(uuid.NewV4())
+	iid := "iid"
+	gid := "gid"
 
 	identity := &Identity{
 		ID:     iid,
 		Scopes: ScopeEncrypt,
-		Groups: map[uuid.UUID]AccessGroup{
+		Groups: map[string]AccessGroup{
 			gid: {gid, ScopeDecrypt},
 		},
 	}
@@ -67,7 +65,7 @@ func TestIDScope(t *testing.T) {
 	if scope := identity.GetIDScope(gid); scope != ScopeDecrypt {
 		t.Fatalf("Expected scope %b but got %b", ScopeDecrypt, scope)
 	}
-	if scope := identity.GetIDScope(uuid.Must(uuid.NewV4())); scope != ScopeNone {
+	if scope := identity.GetIDScope("non-existent ID"); scope != ScopeNone {
 		t.Fatalf("Expected scope %b but got %b", ScopeNone, scope)
 	}
 }

--- a/id/standalone.go
+++ b/id/standalone.go
@@ -207,7 +207,7 @@ func (s *Standalone) AddUserToGroups(token, uid string, gids ...string) error {
 
 // RemoveUserFromGroups removes the user from the provided groups. The authorizing user must be a
 // member of all the groups.
-func (s *Standalone) RemoveUserFromGroups(token string, uid string, gids ...string) error {
+func (s *Standalone) RemoveUserFromGroups(token, uid string, gids ...string) error {
 	// Authenticate calling user
 	identity, err := s.GetIdentity(token)
 	if err != nil {

--- a/id/standalone.go
+++ b/id/standalone.go
@@ -86,17 +86,14 @@ func (s *Standalone) GetIdentity(token string) (Identity, error) {
 		return Identity{}, err
 	}
 
-	id, err := uuid.FromBytes(plainToken.Plaintext)
-	if err != nil {
-		return Identity{}, err
-	}
+	id := string(plainToken.Plaintext)
 
 	user, err := s.getUser(id)
 	if err != nil {
 		return Identity{}, err
 	}
 
-	groups := make(map[uuid.UUID]AccessGroup, len(user.Groups))
+	groups := make(map[string]AccessGroup, len(user.Groups))
 	for gid := range user.getGroups() {
 		group, err := s.getGroup(gid)
 		if err != nil {
@@ -114,26 +111,27 @@ func (s *Standalone) GetIdentity(token string) (Identity, error) {
 }
 
 // NewUser creates a new user with a randomly generated ID and password.
-func (s *Standalone) NewUser(scopes ...Scope) (uuid.UUID, string, error) {
+func (s *Standalone) NewUser(scopes ...Scope) (string, string, error) {
 	uid, err := uuid.NewV4()
 	if err != nil {
-		return uuid.Nil, "", err
+		return "", "", err
 	}
+	uidString := uid.String()
 
 	user, password, err := newUser(scopes...)
 	if err != nil {
-		return uuid.Nil, "", err
+		return "", "", err
 	}
-	if err := s.putUser(uid, &user, false); err != nil {
-		return uuid.Nil, "", err
+	if err := s.putUser(uidString, &user, false); err != nil {
+		return "", "", err
 	}
 
-	return uid, password, nil
+	return uidString, password, nil
 }
 
 // LoginUser checks whether the password provided matches the user. If authentication is successful
 // a token is generated and returned alongside its expiry time in Unix time.
-func (s *Standalone) LoginUser(uid uuid.UUID, password string) (string, int64, error) {
+func (s *Standalone) LoginUser(uid string, password string) (string, int64, error) {
 	user, err := s.getUser(uid)
 	if err != nil {
 		return "", 0, ErrNotAuthenticated
@@ -143,7 +141,7 @@ func (s *Standalone) LoginUser(uid uuid.UUID, password string) (string, int64, e
 		return "", 0, ErrNotAuthenticated
 	}
 
-	token := data.NewToken(uid.Bytes(), data.TokenValidity)
+	token := data.NewToken([]byte(uid), data.TokenValidity)
 	sealedToken, err := token.Seal(s.tokenCryptor)
 	if err != nil {
 		return "", 0, ErrNotAuthenticated
@@ -159,7 +157,7 @@ func (s *Standalone) LoginUser(uid uuid.UUID, password string) (string, int64, e
 
 // ChangeUserPassword authenticates the provided user with the given password and generates a new
 // password for the user.
-func (s *Standalone) ChangeUserPassword(uid uuid.UUID, oldPassword string) (string, error) {
+func (s *Standalone) ChangeUserPassword(uid string, oldPassword string) (string, error) {
 	user, err := s.getUser(uid)
 	if err != nil {
 		return "", err
@@ -178,7 +176,7 @@ func (s *Standalone) ChangeUserPassword(uid uuid.UUID, oldPassword string) (stri
 
 // AddUserToGroups adds the user to the provided groups. The authorizing user must be a member of
 // all the groups.
-func (s *Standalone) AddUserToGroups(token string, uid uuid.UUID, gids ...uuid.UUID) error {
+func (s *Standalone) AddUserToGroups(token string, uid string, gids ...string) error {
 	// Authenticate calling user
 	identity, err := s.GetIdentity(token)
 	if err != nil {
@@ -209,7 +207,7 @@ func (s *Standalone) AddUserToGroups(token string, uid uuid.UUID, gids ...uuid.U
 
 // RemoveUserFromGroups removes the user from the provided groups. The authorizing user must be a
 // member of all the groups.
-func (s *Standalone) RemoveUserFromGroups(token string, uid uuid.UUID, gids ...uuid.UUID) error {
+func (s *Standalone) RemoveUserFromGroups(token string, uid string, gids ...string) error {
 	// Authenticate calling user
 	identity, err := s.GetIdentity(token)
 	if err != nil {
@@ -238,49 +236,50 @@ func (s *Standalone) RemoveUserFromGroups(token string, uid uuid.UUID, gids ...u
 }
 
 // DeleteUser deletes the user from the IO Provider.
-func (s *Standalone) DeleteUser(token string, uid uuid.UUID) error {
+func (s *Standalone) DeleteUser(token string, uid string) error {
 	// Authenticate calling user
 	if _, err := s.GetIdentity(token); err != nil {
 		return err
 	}
 
-	return s.ioProvider.Delete(uid.Bytes(), DataTypeSealedUser)
+	return s.ioProvider.Delete([]byte(uid), DataTypeSealedUser)
 }
 
 // NewGroup creates a new group and adds the calling user to it.
-func (s *Standalone) NewGroup(token string, scopes ...Scope) (uuid.UUID, error) {
+func (s *Standalone) NewGroup(token string, scopes ...Scope) (string, error) {
 	identity, err := s.GetIdentity(token)
 	if err != nil {
-		return uuid.Nil, err
+		return "", err
 	}
 
 	gid, err := uuid.NewV4()
 	if err != nil {
-		return uuid.Nil, err
+		return "", err
 	}
+	gidString := gid.String()
 
 	group := newGroup(scopes...)
-	if err := s.putGroup(gid, &group); err != nil {
-		return uuid.Nil, err
+	if err := s.putGroup(gidString, &group); err != nil {
+		return "", err
 	}
 
 	// Add caller to group
 	user, err := s.getUser(identity.ID)
 	if err != nil {
-		return uuid.Nil, err
+		return "", err
 	}
 
-	user.addGroups(gid)
+	user.addGroups(gidString)
 	if err := s.putUser(identity.ID, user, true); err != nil {
-		return uuid.Nil, err
+		return "", err
 	}
 
-	return gid, nil
+	return gidString, nil
 }
 
 // putUser seals the user, encodes the sealed user, and sends it to the IO Provider, either as a
 // "Put" or an "Update".
-func (s *Standalone) putUser(uid uuid.UUID, user *User, update bool) error {
+func (s *Standalone) putUser(uid string, user *User, update bool) error {
 	sealedUser, err := user.seal(uid, s.userCryptor)
 	if err != nil {
 		return err
@@ -293,14 +292,14 @@ func (s *Standalone) putUser(uid uuid.UUID, user *User, update bool) error {
 	}
 
 	if update {
-		return s.ioProvider.Update(sealedUser.UID.Bytes(), DataTypeSealedUser, userBuffer.Bytes())
+		return s.ioProvider.Update([]byte(sealedUser.UID), DataTypeSealedUser, userBuffer.Bytes())
 	}
-	return s.ioProvider.Put(sealedUser.UID.Bytes(), DataTypeSealedUser, userBuffer.Bytes())
+	return s.ioProvider.Put([]byte(sealedUser.UID), DataTypeSealedUser, userBuffer.Bytes())
 }
 
 // getUser fetches bytes from the IO Provider, decodes them into a sealed user, and unseals it.
-func (s *Standalone) getUser(uid uuid.UUID) (*User, error) {
-	userBytes, err := s.ioProvider.Get(uid.Bytes(), DataTypeSealedUser)
+func (s *Standalone) getUser(uid string) (*User, error) {
+	userBytes, err := s.ioProvider.Get([]byte(uid), DataTypeSealedUser)
 	if err != nil {
 		return nil, err
 	}
@@ -312,7 +311,6 @@ func (s *Standalone) getUser(uid uuid.UUID) (*User, error) {
 		return nil, err
 	}
 
-	user.UID = uid
 	plainUser, err := user.unseal(s.userCryptor)
 	if err != nil {
 		return nil, err
@@ -322,7 +320,7 @@ func (s *Standalone) getUser(uid uuid.UUID) (*User, error) {
 }
 
 // putGroup seals a group, encodes the sealed group, and sends it to the IO Provider.
-func (s *Standalone) putGroup(gid uuid.UUID, group *Group) error {
+func (s *Standalone) putGroup(gid string, group *Group) error {
 	sealedGroup, err := group.seal(gid, s.groupCryptor)
 	if err != nil {
 		return err
@@ -334,12 +332,12 @@ func (s *Standalone) putGroup(gid uuid.UUID, group *Group) error {
 		return err
 	}
 
-	return s.ioProvider.Put(sealedGroup.GID.Bytes(), DataTypeSealedGroup, groupBuffer.Bytes())
+	return s.ioProvider.Put([]byte(sealedGroup.GID), DataTypeSealedGroup, groupBuffer.Bytes())
 }
 
 // getGroup fetches bytes from the IO Provider, decodes them into a sealed group, and unseals it.
-func (s *Standalone) getGroup(gid uuid.UUID) (*Group, error) {
-	groupBytes, err := s.ioProvider.Get(gid.Bytes(), DataTypeSealedGroup)
+func (s *Standalone) getGroup(gid string) (*Group, error) {
+	groupBytes, err := s.ioProvider.Get([]byte(gid), DataTypeSealedGroup)
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +349,6 @@ func (s *Standalone) getGroup(gid uuid.UUID) (*Group, error) {
 		return nil, err
 	}
 
-	group.GID = gid
 	plainGroup, err := group.unseal(s.groupCryptor)
 	if err != nil {
 		return nil, err

--- a/id/standalone.go
+++ b/id/standalone.go
@@ -236,7 +236,7 @@ func (s *Standalone) RemoveUserFromGroups(token, uid string, gids ...string) err
 }
 
 // DeleteUser deletes the user from the IO Provider.
-func (s *Standalone) DeleteUser(token string, uid string) error {
+func (s *Standalone) DeleteUser(token, uid string) error {
 	// Authenticate calling user
 	if _, err := s.GetIdentity(token); err != nil {
 		return err

--- a/id/standalone.go
+++ b/id/standalone.go
@@ -157,7 +157,7 @@ func (s *Standalone) LoginUser(uid, password string) (string, int64, error) {
 
 // ChangeUserPassword authenticates the provided user with the given password and generates a new
 // password for the user.
-func (s *Standalone) ChangeUserPassword(uid string, oldPassword string) (string, error) {
+func (s *Standalone) ChangeUserPassword(uid, oldPassword string) (string, error) {
 	user, err := s.getUser(uid)
 	if err != nil {
 		return "", err

--- a/id/standalone.go
+++ b/id/standalone.go
@@ -131,7 +131,7 @@ func (s *Standalone) NewUser(scopes ...Scope) (string, string, error) {
 
 // LoginUser checks whether the password provided matches the user. If authentication is successful
 // a token is generated and returned alongside its expiry time in Unix time.
-func (s *Standalone) LoginUser(uid string, password string) (string, int64, error) {
+func (s *Standalone) LoginUser(uid, password string) (string, int64, error) {
 	user, err := s.getUser(uid)
 	if err != nil {
 		return "", 0, ErrNotAuthenticated

--- a/id/standalone.go
+++ b/id/standalone.go
@@ -176,7 +176,7 @@ func (s *Standalone) ChangeUserPassword(uid, oldPassword string) (string, error)
 
 // AddUserToGroups adds the user to the provided groups. The authorizing user must be a member of
 // all the groups.
-func (s *Standalone) AddUserToGroups(token string, uid string, gids ...string) error {
+func (s *Standalone) AddUserToGroups(token, uid string, gids ...string) error {
 	// Authenticate calling user
 	identity, err := s.GetIdentity(token)
 	if err != nil {

--- a/id/standalone_group.go
+++ b/id/standalone_group.go
@@ -16,8 +16,6 @@
 package id
 
 import (
-	"github.com/gofrs/uuid"
-
 	"github.com/cybercryptio/d1-lib/crypto"
 )
 
@@ -29,8 +27,8 @@ type Group struct {
 
 // SealedGroup is an encrypted structure which contains data about a user group.
 type SealedGroup struct {
-	// The unique ID of the group.
-	GID uuid.UUID
+	// The group identifier.
+	GID string
 
 	Ciphertext []byte
 	WrappedKey []byte
@@ -42,8 +40,8 @@ func newGroup(scopes ...Scope) Group {
 }
 
 // seal encrypts the group.
-func (g *Group) seal(gid uuid.UUID, cryptor crypto.CryptorInterface) (SealedGroup, error) {
-	wrappedKey, ciphertext, err := cryptor.Encrypt(g, gid.Bytes())
+func (g *Group) seal(gid string, cryptor crypto.CryptorInterface) (SealedGroup, error) {
+	wrappedKey, ciphertext, err := cryptor.Encrypt(g, gid)
 	if err != nil {
 		return SealedGroup{}, err
 	}
@@ -54,7 +52,7 @@ func (g *Group) seal(gid uuid.UUID, cryptor crypto.CryptorInterface) (SealedGrou
 // unseal decrypts the sealed group.
 func (g *SealedGroup) unseal(cryptor crypto.CryptorInterface) (Group, error) {
 	plainGroup := Group{}
-	if err := cryptor.Decrypt(&plainGroup, g.GID.Bytes(), g.WrappedKey, g.Ciphertext); err != nil {
+	if err := cryptor.Decrypt(&plainGroup, g.GID, g.WrappedKey, g.Ciphertext); err != nil {
 		return Group{}, err
 	}
 	return plainGroup, nil

--- a/id/standalone_group_test.go
+++ b/id/standalone_group_test.go
@@ -20,8 +20,6 @@ import (
 
 	"reflect"
 
-	"github.com/gofrs/uuid"
-
 	"github.com/cybercryptio/d1-lib/crypto"
 )
 
@@ -33,7 +31,7 @@ func TestGroupSeal(t *testing.T) {
 	}
 
 	group := newGroup(ScopeEncrypt)
-	sealed, err := group.seal(uuid.Must(uuid.NewV4()), &cryptor)
+	sealed, err := group.seal("groupID", &cryptor)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +53,7 @@ func TestGroupVerifyCiphertext(t *testing.T) {
 	}
 
 	group := newGroup(ScopeEncrypt)
-	sealed, err := group.seal(uuid.Must(uuid.NewV4()), &cryptor)
+	sealed, err := group.seal("groupID", &cryptor)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +75,7 @@ func TestGroupVerifyID(t *testing.T) {
 	}
 
 	group := newGroup(ScopeEncrypt)
-	sealed, err := group.seal(uuid.Must(uuid.NewV4()), &cryptor)
+	sealed, err := group.seal("groupID", &cryptor)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +83,7 @@ func TestGroupVerifyID(t *testing.T) {
 	if !sealed.verify(&cryptor) {
 		t.Fatal("Verification failed")
 	}
-	sealed.GID = uuid.Must(uuid.NewV4())
+	sealed.GID = "wrongID"
 	if sealed.verify(&cryptor) {
 		t.Fatal("Verification should have failed")
 	}
@@ -99,11 +97,11 @@ func TestGroupID(t *testing.T) {
 	}
 
 	group := newGroup(ScopeEncrypt)
-	sealed1, err := group.seal(uuid.Must(uuid.NewV4()), &cryptor)
+	sealed1, err := group.seal("groupID1", &cryptor)
 	if err != nil {
 		t.Fatal(err)
 	}
-	sealed2, err := group.seal(uuid.Must(uuid.NewV4()), &cryptor)
+	sealed2, err := group.seal("groupID2", &cryptor)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/id/standalone_test.go
+++ b/id/standalone_test.go
@@ -20,8 +20,6 @@ import (
 
 	"reflect"
 
-	"github.com/gofrs/uuid"
-
 	"github.com/cybercryptio/d1-lib/io"
 )
 
@@ -42,14 +40,14 @@ func newTestStandalone(t *testing.T) *Standalone {
 	return &standalone
 }
 
-func manipulateUser(t *testing.T, uid uuid.UUID, standalone *Standalone) {
-	userBytes, err := standalone.ioProvider.Get(uid.Bytes(), DataTypeSealedUser)
+func manipulateUser(t *testing.T, uid string, standalone *Standalone) {
+	userBytes, err := standalone.ioProvider.Get([]byte(uid), DataTypeSealedUser)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	copy(userBytes[:5], make([]byte, 5))
-	if err := standalone.ioProvider.Update(uid.Bytes(), DataTypeSealedUser, userBytes); err != nil {
+	if err := standalone.ioProvider.Update([]byte(uid), DataTypeSealedUser, userBytes); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -473,7 +471,7 @@ func TestNewGroupInvalidUser(t *testing.T) {
 	if err == nil {
 		t.Fatal("Invalid user able to create a new group")
 	}
-	if gid != uuid.Nil {
+	if gid != "" {
 		t.Fatal("NewGroup failed, but returned group ID anyway")
 	}
 }

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -19,8 +19,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/gofrs/uuid"
-
 	"github.com/cybercryptio/d1-lib/id"
 	"github.com/cybercryptio/d1-lib/io"
 	"github.com/cybercryptio/d1-lib/key"
@@ -53,7 +51,7 @@ func newTestSecureIndex(t *testing.T) SecureIndex {
 	return secureIndex
 }
 
-func newTestUser(t *testing.T, secureIndex *SecureIndex, scopes ...id.Scope) (uuid.UUID, string) {
+func newTestUser(t *testing.T, secureIndex *SecureIndex, scopes ...id.Scope) (string, string) {
 	idProvider := secureIndex.idProvider.(*id.Standalone)
 
 	id, password, err := idProvider.NewUser(scopes...)


### PR DESCRIPTION
### Description

- This PR replaces UUIDs with strings for identifying `Identity` objects, offering more flexibility to the implementers of the ID Provider interface and making the library API more consistent
- The Standalone Identity Provider implementation still uses UUIDs internally, just encapsulated in strings

### Relevant Issues/PRs

Closes DEV-248

### Type(s) of Change (Split the PR if you check many)

- [ ] Added user feature
- [ ] Added technical feature
- [ ] Added tests
- [x] Refactor
- [ ] Bugfix
- [x] Updated documentation
- [ ] Kubernetes changes
- [ ] CI/CD workflow changes

### Testing Checklist

- [ ] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist

- [x] I have pulled in the latest changes from master.
- [x] I have run `make lint`.
- [x] I have successfully run `make tests`.
- [ ] I have updated relevant CI/CD workflows.
- [ ] I have updated relevant Kubernetes manifests/scripts.
- [x] I have updated/added relevant (internal and external) documentation (readme, doc comments, etc).
- [ ] I have updated the dependency map to reflect my changes.
- [ ] I have added the license to new source code files.
- [x] I have spent some time looking over the full diff before creating this PR.
