### PR TITLE
Allow for adding groups to the access object when encrypting

### DIFF
--- a/d1.go
+++ b/d1.go
@@ -84,7 +84,8 @@ func New(keyProvider key.Provider, ioProvider io.Provider, idProvider id.Provide
 
 // Encrypt creates a new sealed object containing the provided plaintext data as well as an access
 // list that controls access to that data. The Identity of the caller is automatically added to the
-// access list. To grant access to other callers, see AddGroupsToAccess.
+// access list. To grant access to other callers either specify them in the optional 'groups'
+// argument or see AddGroupsToAccess.
 //
 // The returned ID is the unique identifier of the sealed object. It is used to identify the object
 // and related data about the object to the IO Provider, and needs to be provided when decrypting
@@ -95,7 +96,7 @@ func New(keyProvider key.Provider, ioProvider io.Provider, idProvider id.Provide
 //
 // Required scopes:
 // - Encrypt
-func (d *D1) Encrypt(token string, object *data.Object) (uuid.UUID, error) {
+func (d *D1) Encrypt(token string, object *data.Object, groups ...string) (uuid.UUID, error) {
 	identity, err := d.idProvider.GetIdentity(token)
 	if err != nil {
 		return uuid.Nil, ErrNotAuthenticated
@@ -115,7 +116,7 @@ func (d *D1) Encrypt(token string, object *data.Object) (uuid.UUID, error) {
 	}
 
 	access := data.NewAccess(wrappedOEK)
-	access.AddGroups(identity.ID)
+	access.AddGroups(append(groups, identity.ID)...)
 	sealedAccess, err := access.Seal(oid, d.accessCryptor)
 	if err != nil {
 		return uuid.Nil, err

--- a/utility.go
+++ b/utility.go
@@ -30,10 +30,10 @@ import (
 // object. If so, the unsealed access object is returned.
 //
 // An Identity is authorized to access an object if at least one of the following is true:
-// * The the Identity's ID is part of the Access and the Identity's scope contains the
-//   required scope.
-// * One of the Identity's group IDs is part of the Access and that group's scope contains the required
-//   scope.
+//   - The the Identity's ID is part of the Access and the Identity's scope contains the
+//     required scope.
+//   - One of the Identity's group IDs is part of the Access and that group's scope contains the required
+//     scope.
 func (d *D1) authorizeAccess(identity *id.Identity, scopes id.Scope, sealedAccess *data.SealedAccess) (data.Access, error) {
 	plainAccess, err := sealedAccess.Unseal(d.accessCryptor)
 	if err != nil {


### PR DESCRIPTION
### Description
This PR adds an extra optional variadic argument to `Encrypt` to allow for an initial access object with several groups. 

### Relevant Issues/PRs
Part of DEV-418

### Type(s) of Change (Split the PR if you check many)
- [x] Added/updated user feature
- [ ] Technical change
- [ ] Refactor
- [ ] Bugfix
- [ ] Dependency update
- [x] Added/updated tests
- [x] Updated documentation
- [ ] Workflow/tooling changes

### Testing Checklist
- [x] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist
- [x] I have pulled in the latest changes from master.
- [ ] I have added the license header to new source code files.
- [x] I have checked the code with linting tools.
- [x] I have successfully run all tests.
- [ ] I have updated relevant CI/CD workflows.
- [x] I have updated/added relevant (internal and external) documentation (readme, doc comments, etc).
- [ ] I have updated the dependency map to reflect my changes.
- [x] I have spent some time looking over the full diff before creating this PR.
