### PR TITLE
Add context to the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,20 +28,20 @@ The CYBERCRYPT D1 library provides cryptographic functions for data encryption a
 To use the library in your Go project, you first need to add it to your `go.mod` file by running the following command in the root folder of the project:
 
 ```
-go get -u github.com/cybercryptio/d1-lib@latest
+go get -u github.com/cybercryptio/d1-lib/v2@latest
 
 ```
 
 Then, you can access the D1 library functions by importing the library in your application code:
 
 ```
-import github.com/cybercryptio/d1-lib
+import github.com/cybercryptio/d1-lib/v2
 
 ```
 
 ## Usage
 
-For examples on how to use the D1 library [see the Examples section in the godocs](https://pkg.go.dev/github.com/cybercryptio/d1-lib#example-package-BasicEncryptDecrypt).
+For examples on how to use the D1 library [see the Examples section in the godocs](https://pkg.go.dev/github.com/cybercryptio/d1-lib/v2#example-package-BasicEncryptDecrypt).
 
 ## High level overview
 
@@ -49,7 +49,7 @@ For a high level overview of the main concepts and use cases of the D1 library [
 
 ## API Reference
 
-The API reference is published available on the Go Packages website at [https://pkg.go.dev/github.com/cybercryptio/d1-lib](https://pkg.go.dev/github.com/cybercryptio/d1-lib)
+The API reference is published available on the Go Packages website at [https://pkg.go.dev/github.com/cybercryptio/d1-lib/v2](https://pkg.go.dev/github.com/cybercryptio/d1-lib/v2)
 
 ## License
 

--- a/d1.go
+++ b/d1.go
@@ -24,11 +24,11 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/cybercryptio/d1-lib/crypto"
-	"github.com/cybercryptio/d1-lib/data"
-	"github.com/cybercryptio/d1-lib/id"
-	"github.com/cybercryptio/d1-lib/io"
-	"github.com/cybercryptio/d1-lib/key"
+	"github.com/cybercryptio/d1-lib/v2/crypto"
+	"github.com/cybercryptio/d1-lib/v2/data"
+	"github.com/cybercryptio/d1-lib/v2/id"
+	"github.com/cybercryptio/d1-lib/v2/io"
+	"github.com/cybercryptio/d1-lib/v2/key"
 )
 
 // Error returned if the caller cannot be authenticated by the Identity Provider.

--- a/d1_test.go
+++ b/d1_test.go
@@ -25,10 +25,10 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/cybercryptio/d1-lib/data"
-	"github.com/cybercryptio/d1-lib/id"
-	"github.com/cybercryptio/d1-lib/io"
-	"github.com/cybercryptio/d1-lib/key"
+	"github.com/cybercryptio/d1-lib/v2/data"
+	"github.com/cybercryptio/d1-lib/v2/id"
+	"github.com/cybercryptio/d1-lib/v2/io"
+	"github.com/cybercryptio/d1-lib/v2/key"
 )
 
 func newTestD1(t *testing.T) D1 {

--- a/data/access.go
+++ b/data/access.go
@@ -18,7 +18,7 @@ package data
 import (
 	"github.com/gofrs/uuid"
 
-	"github.com/cybercryptio/d1-lib/crypto"
+	"github.com/cybercryptio/d1-lib/v2/crypto"
 )
 
 // Access is used to manage access to encrypted objects. Note: All member fields need to be exported

--- a/data/access_test.go
+++ b/data/access_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/cybercryptio/d1-lib/crypto"
+	"github.com/cybercryptio/d1-lib/v2/crypto"
 )
 
 var groupIDs = []string{

--- a/data/node.go
+++ b/data/node.go
@@ -18,7 +18,7 @@ package data
 import (
 	"encoding/binary"
 
-	"github.com/cybercryptio/d1-lib/crypto"
+	"github.com/cybercryptio/d1-lib/v2/crypto"
 )
 
 // Node contains an identifier (e.g. a document ID) and the counter used to compute the next label.

--- a/data/node_test.go
+++ b/data/node_test.go
@@ -20,7 +20,7 @@ import (
 
 	"reflect"
 
-	"github.com/cybercryptio/d1-lib/crypto"
+	"github.com/cybercryptio/d1-lib/v2/crypto"
 )
 
 func TestNextLabel(t *testing.T) {

--- a/data/object.go
+++ b/data/object.go
@@ -18,7 +18,7 @@ package data
 import (
 	"github.com/gofrs/uuid"
 
-	"github.com/cybercryptio/d1-lib/crypto"
+	"github.com/cybercryptio/d1-lib/v2/crypto"
 )
 
 // Object contains plaintext data provided to D1 for encryption.

--- a/data/object_test.go
+++ b/data/object_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/cybercryptio/d1-lib/crypto"
+	"github.com/cybercryptio/d1-lib/v2/crypto"
 )
 
 var id = uuid.FromStringOrNil("10000000-0000-0000-0000-000000000000")

--- a/data/token.go
+++ b/data/token.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/cybercryptio/d1-lib/crypto"
+	"github.com/cybercryptio/d1-lib/v2/crypto"
 )
 
 // Validity period of tokens created with D1.CreateToken.

--- a/data/token_test.go
+++ b/data/token_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/cybercryptio/d1-lib/crypto"
+	"github.com/cybercryptio/d1-lib/v2/crypto"
 )
 
 func TestTokenSeal(t *testing.T) {

--- a/documentation/explainer.md
+++ b/documentation/explainer.md
@@ -12,15 +12,15 @@ This document defines the main concepts and use cases for the D1 library.
 
 ### Key Provider
 
-The **Key Provider** is the source of cryptographic key material for the library. Implementations of its [interface](https://pkg.go.dev/github.com/cybercryptio/d1-lib/key#Provider) must be able to provide four 256-bit keys: Key Encryption Key (KEK), Access Encryption Key (AEK), Token Encryption Key (TEK), Index Encryption Key (IEK).
+The **Key Provider** is the source of cryptographic key material for the library. Implementations of its [interface](https://pkg.go.dev/github.com/cybercryptio/d1-lib/v2/key#Provider) must be able to provide four 256-bit keys: Key Encryption Key (KEK), Access Encryption Key (AEK), Token Encryption Key (TEK), Index Encryption Key (IEK).
 
 ### IO Provider
 
-The **IO Provider** acts as a source and destination for the [encrypted data](#data-concepts) produced/consumed by the library. Implementations of its [interface](https://pkg.go.dev/github.com/cybercryptio/d1-lib/io#Provider) could use various types of storage, for example: blob storage, relational databases, queues, in-memory storage, etc.
+The **IO Provider** acts as a source and destination for the [encrypted data](#data-concepts) produced/consumed by the library. Implementations of its [interface](https://pkg.go.dev/github.com/cybercryptio/d1-lib/v2/io#Provider) could use various types of storage, for example: blob storage, relational databases, queues, in-memory storage, etc.
 
 ### Identity Provider
 
-The **Identity Provider** is the source of identifying information about the caller of the library. It allows the library to validate [**Identity Tokens**](#identity-token) and fetch their corresponding [**Identity**](#identity) objects. Implementations of its [interface](https://pkg.go.dev/github.com/cybercryptio/d1-lib/id#Provider) could use various Identity and Access Management (IAM) solutions such as SAML or OpenID. For easily getting up and running, the library implements a [**Standalone Identity Provider**](#standalone-identity-provider).
+The **Identity Provider** is the source of identifying information about the caller of the library. It allows the library to validate [**Identity Tokens**](#identity-token) and fetch their corresponding [**Identity**](#identity) objects. Implementations of its [interface](https://pkg.go.dev/github.com/cybercryptio/d1-lib/v2/id#Provider) could use various Identity and Access Management (IAM) solutions such as SAML or OpenID. For easily getting up and running, the library implements a [**Standalone Identity Provider**](#standalone-identity-provider).
 
 ### Identity
 
@@ -33,7 +33,7 @@ The **Identity Provider** implementation must decide the format of the identifyi
 
 ### Scope
 
-**Scopes** are used to control access to the [**Encrypted Objects**](#object). **Identities** have associated **Scopes**, and they can only perform operations on [**Data**](#data-concepts) when they have the required scopes. [See our documentation for examples of how to enforce access control using the D1 library.](https://pkg.go.dev/github.com/cybercryptio/d1-lib#example-package-AccessControl)
+**Scopes** are used to control access to the [**Encrypted Objects**](#object). **Identities** have associated **Scopes**, and they can only perform operations on [**Data**](#data-concepts) when they have the required scopes. [See our documentation for examples of how to enforce access control using the D1 library.](https://pkg.go.dev/github.com/cybercryptio/d1-lib/v2#example-package-AccessControl)
 
 ### Identity Token
 
@@ -41,7 +41,7 @@ The **Identity Provider** implementation must decide the format of the identifyi
 
 ### Standalone Identity Provider
 
-The [**Standalone Identity Provider**](https://pkg.go.dev/github.com/cybercryptio/d1-lib/id#Standalone) is an **Identity Provider** implementation designed to easily get up and running for the library users who do not have an existing IAM system in place. It provides the following functionalities:
+The [**Standalone Identity Provider**](https://pkg.go.dev/github.com/cybercryptio/d1-lib/v2/id#Standalone) is an **Identity Provider** implementation designed to easily get up and running for the library users who do not have an existing IAM system in place. It provides the following functionalities:
 - Creating and managing **Users**, **Groups** and **Identity Tokens**;
 - Translating between **Identity Tokens** and **Identities**;
 - Storing the user data with the configured **IO Provider**;

--- a/example_access_control_test.go
+++ b/example_access_control_test.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	d1lib "github.com/cybercryptio/d1-lib"
-	"github.com/cybercryptio/d1-lib/data"
+	d1lib "github.com/cybercryptio/d1-lib/v2"
+	"github.com/cybercryptio/d1-lib/v2/data"
 )
 
 // The UserData struct models the data of a user. It contains both private data that should be kept confidential and public data that can be shared

--- a/example_access_control_test.go
+++ b/example_access_control_test.go
@@ -16,6 +16,7 @@
 package d1_test
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -44,20 +45,20 @@ type PublicUserData struct {
 }
 
 // createUserData instantiates a user with its private and public data.
-func createUserData(d1 d1lib.D1) UserData {
-	uid, gid, token := NewUser()
+func createUserData(ctx context.Context, d1 d1lib.D1) UserData {
+	uid, gid, token := NewUser(ctx)
 
 	privateUserObject := data.Object{
 		Plaintext:      []byte("Plaintext"),
 		AssociatedData: []byte("AssociatedData"),
 	}
 
-	oid, err := d1.Encrypt(token, &privateUserObject)
+	oid, err := d1.Encrypt(ctx, token, &privateUserObject)
 	if err != nil {
 		log.Fatalf("Error encrypting object: %v", err)
 	}
 
-	err = d1.AddGroupsToAccess(token, oid, gid)
+	err = d1.AddGroupsToAccess(ctx, token, oid, gid)
 	if err != nil {
 		log.Fatalf("Error adding group to access list: %v", err)
 	}
@@ -70,38 +71,40 @@ func createUserData(d1 d1lib.D1) UserData {
 
 // This example demonstrates how to use the D1 library to enforce discretionary access control for binary data.
 func Example_accessControl() {
+	ctx := context.Background()
+
 	// Instantiate the D1 library with the given keys.
-	d1, err := d1lib.New(&keyProvider, &ioProvider, &idProvider)
+	d1, err := d1lib.New(ctx, &keyProvider, &ioProvider, &idProvider)
 	if err != nil {
 		log.Fatalf("Error instantiating D1: %v", err)
 	}
 
 	// Create three users with their data.
-	alice := createUserData(d1)
-	bob := createUserData(d1)
-	charlie := createUserData(d1)
+	alice := createUserData(ctx, d1)
+	bob := createUserData(ctx, d1)
+	charlie := createUserData(ctx, d1)
 
 	// charlie wants to share her data with bob.
-	err = d1.AddGroupsToAccess(charlie.private.token, charlie.public.oid, bob.public.uid)
+	err = d1.AddGroupsToAccess(ctx, charlie.private.token, charlie.public.oid, bob.public.uid)
 	if err != nil {
 		log.Fatalf("Error adding group to access: %v", err)
 	}
 
 	// bob can now decrypt charlie's encrypted data.
-	charliesDecryptedData, err := d1.Decrypt(bob.private.token, charlie.public.oid)
+	charliesDecryptedData, err := d1.Decrypt(ctx, bob.private.token, charlie.public.oid)
 	if err != nil {
 		log.Fatalf("Error decrypting object: %v", err)
 	}
 	fmt.Printf("%s %s\n", charliesDecryptedData.Plaintext, charliesDecryptedData.AssociatedData)
 
 	// alice wants to form a group with charlie so that all of his previously encrypted data can be decrypted by charlie.
-	err = idProvider.AddUserToGroups(alice.private.token, charlie.public.uid, alice.public.gid)
+	err = idProvider.AddUserToGroups(ctx, alice.private.token, charlie.public.uid, alice.public.gid)
 	if err != nil {
 		log.Fatalf("Error adding user to group: %v", err)
 	}
 
 	// charlie can now decrypt all of alice's previously encrypted data.
-	alicesDecryptedData, err := d1.Decrypt(charlie.private.token, alice.public.oid)
+	alicesDecryptedData, err := d1.Decrypt(ctx, charlie.private.token, alice.public.oid)
 	if err != nil {
 		log.Fatalf("Error decrypting object: %v", err)
 	}

--- a/example_basic_test.go
+++ b/example_basic_test.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"log"
 
-	d1lib "github.com/cybercryptio/d1-lib"
-	"github.com/cybercryptio/d1-lib/data"
-	"github.com/cybercryptio/d1-lib/id"
-	"github.com/cybercryptio/d1-lib/io"
-	"github.com/cybercryptio/d1-lib/key"
+	d1lib "github.com/cybercryptio/d1-lib/v2"
+	"github.com/cybercryptio/d1-lib/v2/data"
+	"github.com/cybercryptio/d1-lib/v2/id"
+	"github.com/cybercryptio/d1-lib/v2/io"
+	"github.com/cybercryptio/d1-lib/v2/key"
 )
 
 // These are insecure keys used only for demonstration purposes.

--- a/example_token_test.go
+++ b/example_token_test.go
@@ -16,6 +16,7 @@
 package d1_test
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -23,20 +24,22 @@ import (
 )
 
 func ExampleD1_CreateToken() {
+	ctx := context.Background()
+
 	// Instantiate the D1 library with the given keys.
-	d1, err := d1lib.New(&keyProvider, &ioProvider, &idProvider)
+	d1, err := d1lib.New(ctx, &keyProvider, &ioProvider, &idProvider)
 	if err != nil {
 		log.Fatalf("Error instantiating D1: %v", err)
 	}
 
 	// Create a token with encrypted contents and default expiry time.
-	token, err := d1.CreateToken([]byte("token contents"))
+	token, err := d1.CreateToken(ctx, []byte("token contents"))
 	if err != nil {
 		log.Fatalf("Error creating token: %v", err)
 	}
 
 	// Validate the token and fetch its decrypted contents. This call will fail if the token has expired or has been tampered with.
-	tokenContents, err := d1.GetTokenContents(&token)
+	tokenContents, err := d1.GetTokenContents(ctx, &token)
 	if err != nil {
 		log.Fatalf("Invalid token: %v", err)
 	}

--- a/example_token_test.go
+++ b/example_token_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"log"
 
-	d1lib "github.com/cybercryptio/d1-lib"
+	d1lib "github.com/cybercryptio/d1-lib/v2"
 )
 
 func ExampleD1_CreateToken() {

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
-module github.com/cybercryptio/d1-lib
+module github.com/cybercryptio/d1-lib/v2
 
 go 1.18
 
 require (
 	github.com/gofrs/uuid v4.2.0+incompatible
 	go.etcd.io/bbolt v1.3.6
-	golang.org/x/crypto v0.0.0-20220210151621-f4118a5b28e2
+	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90
 )
 
-require golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
+require golang.org/x/sys v0.0.0-20220907062415-87db552b00fd // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/gofrs/uuid v4.2.0+incompatible h1:yyYWMnhkhrKwwr8gAOcOCYxOOscHgDS9yZg
 github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 go.etcd.io/bbolt v1.3.6 h1:/ecaJf0sk1l4l6V4awd65v2C3ILy7MSj+s/x1ADCIMU=
 go.etcd.io/bbolt v1.3.6/go.mod h1:qXsaaIqmgQH0T+OPdb99Bf+PKfBBQVAdyD6TY9G8XM4=
-golang.org/x/crypto v0.0.0-20220210151621-f4118a5b28e2 h1:XdAboW3BNMv9ocSCOk/u1MFioZGzCNkiJZ19v9Oe3Ig=
-golang.org/x/crypto v0.0.0-20220210151621-f4118a5b28e2/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 h1:Y/gsMcFOcR+6S6f3YeMKl5g+dZMEWqcz5Czj/GWYbkM=
+golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220907062415-87db552b00fd h1:AZeIEzg+8RCELJYq8w+ODLVxFgLMMigSwO/ffKPEd9U=
+golang.org/x/sys v0.0.0-20220907062415-87db552b00fd/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/id/id.go
+++ b/id/id.go
@@ -15,6 +15,10 @@
 
 package id
 
+import (
+	"context"
+)
+
 // AccessGroup represents a group of Identities. The Provider implementations should ensure that the
 // ID string is unique across all instances.
 type AccessGroup struct {
@@ -52,5 +56,5 @@ func (i *Identity) GetIDScope(id string) Scope {
 }
 
 type Provider interface {
-	GetIdentity(token string) (Identity, error)
+	GetIdentity(ctx context.Context, token string) (Identity, error)
 }

--- a/id/standalone.go
+++ b/id/standalone.go
@@ -23,9 +23,9 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/cybercryptio/d1-lib/crypto"
-	"github.com/cybercryptio/d1-lib/data"
-	"github.com/cybercryptio/d1-lib/io"
+	"github.com/cybercryptio/d1-lib/v2/crypto"
+	"github.com/cybercryptio/d1-lib/v2/data"
+	"github.com/cybercryptio/d1-lib/v2/io"
 )
 
 var ErrNotFound = errors.New("not found")

--- a/id/standalone.go
+++ b/id/standalone.go
@@ -17,6 +17,7 @@ package id
 
 import (
 	"bytes"
+	"context"
 	"encoding/gob"
 	"errors"
 
@@ -75,7 +76,7 @@ func NewStandalone(config StandaloneConfig, ioProvider io.Provider) (Standalone,
 	}, nil
 }
 
-func (s *Standalone) GetIdentity(token string) (Identity, error) {
+func (s *Standalone) GetIdentity(ctx context.Context, token string) (Identity, error) {
 	sealedToken, err := data.TokenFromString(token)
 	if err != nil {
 		return Identity{}, err
@@ -88,14 +89,14 @@ func (s *Standalone) GetIdentity(token string) (Identity, error) {
 
 	id := string(plainToken.Plaintext)
 
-	user, err := s.getUser(id)
+	user, err := s.getUser(ctx, id)
 	if err != nil {
 		return Identity{}, err
 	}
 
 	groups := make(map[string]AccessGroup, len(user.Groups))
 	for gid := range user.getGroups() {
-		group, err := s.getGroup(gid)
+		group, err := s.getGroup(ctx, gid)
 		if err != nil {
 			return Identity{}, err
 		}
@@ -111,7 +112,7 @@ func (s *Standalone) GetIdentity(token string) (Identity, error) {
 }
 
 // NewUser creates a new user with a randomly generated ID and password.
-func (s *Standalone) NewUser(scopes ...Scope) (string, string, error) {
+func (s *Standalone) NewUser(ctx context.Context, scopes ...Scope) (string, string, error) {
 	uid, err := uuid.NewV4()
 	if err != nil {
 		return "", "", err
@@ -122,7 +123,7 @@ func (s *Standalone) NewUser(scopes ...Scope) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	if err := s.putUser(uidString, &user, false); err != nil {
+	if err := s.putUser(ctx, uidString, &user, false); err != nil {
 		return "", "", err
 	}
 
@@ -131,8 +132,8 @@ func (s *Standalone) NewUser(scopes ...Scope) (string, string, error) {
 
 // LoginUser checks whether the password provided matches the user. If authentication is successful
 // a token is generated and returned alongside its expiry time in Unix time.
-func (s *Standalone) LoginUser(uid, password string) (string, int64, error) {
-	user, err := s.getUser(uid)
+func (s *Standalone) LoginUser(ctx context.Context, uid, password string) (string, int64, error) {
+	user, err := s.getUser(ctx, uid)
 	if err != nil {
 		return "", 0, ErrNotAuthenticated
 	}
@@ -157,8 +158,8 @@ func (s *Standalone) LoginUser(uid, password string) (string, int64, error) {
 
 // ChangeUserPassword authenticates the provided user with the given password and generates a new
 // password for the user.
-func (s *Standalone) ChangeUserPassword(uid, oldPassword string) (string, error) {
-	user, err := s.getUser(uid)
+func (s *Standalone) ChangeUserPassword(ctx context.Context, uid, oldPassword string) (string, error) {
+	user, err := s.getUser(ctx, uid)
 	if err != nil {
 		return "", err
 	}
@@ -167,7 +168,7 @@ func (s *Standalone) ChangeUserPassword(uid, oldPassword string) (string, error)
 	if err != nil {
 		return "", err
 	}
-	if err := s.putUser(uid, user, true); err != nil {
+	if err := s.putUser(ctx, uid, user, true); err != nil {
 		return "", err
 	}
 
@@ -176,9 +177,9 @@ func (s *Standalone) ChangeUserPassword(uid, oldPassword string) (string, error)
 
 // AddUserToGroups adds the user to the provided groups. The authorizing user must be a member of
 // all the groups.
-func (s *Standalone) AddUserToGroups(token, uid string, gids ...string) error {
+func (s *Standalone) AddUserToGroups(ctx context.Context, token, uid string, gids ...string) error {
 	// Authenticate calling user
-	identity, err := s.GetIdentity(token)
+	identity, err := s.GetIdentity(ctx, token)
 	if err != nil {
 		return err
 	}
@@ -192,13 +193,13 @@ func (s *Standalone) AddUserToGroups(token, uid string, gids ...string) error {
 	}
 
 	// Update user
-	user, err := s.getUser(uid)
+	user, err := s.getUser(ctx, uid)
 	if err != nil {
 		return err
 	}
 
 	user.addGroups(gids...)
-	if err := s.putUser(uid, user, true); err != nil {
+	if err := s.putUser(ctx, uid, user, true); err != nil {
 		return err
 	}
 
@@ -207,9 +208,9 @@ func (s *Standalone) AddUserToGroups(token, uid string, gids ...string) error {
 
 // RemoveUserFromGroups removes the user from the provided groups. The authorizing user must be a
 // member of all the groups.
-func (s *Standalone) RemoveUserFromGroups(token, uid string, gids ...string) error {
+func (s *Standalone) RemoveUserFromGroups(ctx context.Context, token, uid string, gids ...string) error {
 	// Authenticate calling user
-	identity, err := s.GetIdentity(token)
+	identity, err := s.GetIdentity(ctx, token)
 	if err != nil {
 		return err
 	}
@@ -222,13 +223,13 @@ func (s *Standalone) RemoveUserFromGroups(token, uid string, gids ...string) err
 		}
 	}
 
-	user, err := s.getUser(uid)
+	user, err := s.getUser(ctx, uid)
 	if err != nil {
 		return err
 	}
 
 	user.removeGroups(gids...)
-	if err := s.putUser(uid, user, true); err != nil {
+	if err := s.putUser(ctx, uid, user, true); err != nil {
 		return err
 	}
 
@@ -236,18 +237,18 @@ func (s *Standalone) RemoveUserFromGroups(token, uid string, gids ...string) err
 }
 
 // DeleteUser deletes the user from the IO Provider.
-func (s *Standalone) DeleteUser(token, uid string) error {
+func (s *Standalone) DeleteUser(ctx context.Context, token, uid string) error {
 	// Authenticate calling user
-	if _, err := s.GetIdentity(token); err != nil {
+	if _, err := s.GetIdentity(ctx, token); err != nil {
 		return err
 	}
 
-	return s.ioProvider.Delete([]byte(uid), DataTypeSealedUser)
+	return s.ioProvider.Delete(ctx, []byte(uid), DataTypeSealedUser)
 }
 
 // NewGroup creates a new group and adds the calling user to it.
-func (s *Standalone) NewGroup(token string, scopes ...Scope) (string, error) {
-	identity, err := s.GetIdentity(token)
+func (s *Standalone) NewGroup(ctx context.Context, token string, scopes ...Scope) (string, error) {
+	identity, err := s.GetIdentity(ctx, token)
 	if err != nil {
 		return "", err
 	}
@@ -259,18 +260,18 @@ func (s *Standalone) NewGroup(token string, scopes ...Scope) (string, error) {
 	gidString := gid.String()
 
 	group := newGroup(scopes...)
-	if err := s.putGroup(gidString, &group); err != nil {
+	if err := s.putGroup(ctx, gidString, &group); err != nil {
 		return "", err
 	}
 
 	// Add caller to group
-	user, err := s.getUser(identity.ID)
+	user, err := s.getUser(ctx, identity.ID)
 	if err != nil {
 		return "", err
 	}
 
 	user.addGroups(gidString)
-	if err := s.putUser(identity.ID, user, true); err != nil {
+	if err := s.putUser(ctx, identity.ID, user, true); err != nil {
 		return "", err
 	}
 
@@ -279,7 +280,7 @@ func (s *Standalone) NewGroup(token string, scopes ...Scope) (string, error) {
 
 // putUser seals the user, encodes the sealed user, and sends it to the IO Provider, either as a
 // "Put" or an "Update".
-func (s *Standalone) putUser(uid string, user *User, update bool) error {
+func (s *Standalone) putUser(ctx context.Context, uid string, user *User, update bool) error {
 	sealedUser, err := user.seal(uid, s.userCryptor)
 	if err != nil {
 		return err
@@ -292,14 +293,14 @@ func (s *Standalone) putUser(uid string, user *User, update bool) error {
 	}
 
 	if update {
-		return s.ioProvider.Update([]byte(sealedUser.UID), DataTypeSealedUser, userBuffer.Bytes())
+		return s.ioProvider.Update(ctx, []byte(sealedUser.UID), DataTypeSealedUser, userBuffer.Bytes())
 	}
-	return s.ioProvider.Put([]byte(sealedUser.UID), DataTypeSealedUser, userBuffer.Bytes())
+	return s.ioProvider.Put(ctx, []byte(sealedUser.UID), DataTypeSealedUser, userBuffer.Bytes())
 }
 
 // getUser fetches bytes from the IO Provider, decodes them into a sealed user, and unseals it.
-func (s *Standalone) getUser(uid string) (*User, error) {
-	userBytes, err := s.ioProvider.Get([]byte(uid), DataTypeSealedUser)
+func (s *Standalone) getUser(ctx context.Context, uid string) (*User, error) {
+	userBytes, err := s.ioProvider.Get(ctx, []byte(uid), DataTypeSealedUser)
 	if err != nil {
 		return nil, err
 	}
@@ -320,7 +321,7 @@ func (s *Standalone) getUser(uid string) (*User, error) {
 }
 
 // putGroup seals a group, encodes the sealed group, and sends it to the IO Provider.
-func (s *Standalone) putGroup(gid string, group *Group) error {
+func (s *Standalone) putGroup(ctx context.Context, gid string, group *Group) error {
 	sealedGroup, err := group.seal(gid, s.groupCryptor)
 	if err != nil {
 		return err
@@ -332,12 +333,12 @@ func (s *Standalone) putGroup(gid string, group *Group) error {
 		return err
 	}
 
-	return s.ioProvider.Put([]byte(sealedGroup.GID), DataTypeSealedGroup, groupBuffer.Bytes())
+	return s.ioProvider.Put(ctx, []byte(sealedGroup.GID), DataTypeSealedGroup, groupBuffer.Bytes())
 }
 
 // getGroup fetches bytes from the IO Provider, decodes them into a sealed group, and unseals it.
-func (s *Standalone) getGroup(gid string) (*Group, error) {
-	groupBytes, err := s.ioProvider.Get([]byte(gid), DataTypeSealedGroup)
+func (s *Standalone) getGroup(ctx context.Context, gid string) (*Group, error) {
+	groupBytes, err := s.ioProvider.Get(ctx, []byte(gid), DataTypeSealedGroup)
 	if err != nil {
 		return nil, err
 	}

--- a/id/standalone_group.go
+++ b/id/standalone_group.go
@@ -16,7 +16,7 @@
 package id
 
 import (
-	"github.com/cybercryptio/d1-lib/crypto"
+	"github.com/cybercryptio/d1-lib/v2/crypto"
 )
 
 // Group contains data about a group of users. Note: All fields need to exported in order for

--- a/id/standalone_group_test.go
+++ b/id/standalone_group_test.go
@@ -20,7 +20,7 @@ import (
 
 	"reflect"
 
-	"github.com/cybercryptio/d1-lib/crypto"
+	"github.com/cybercryptio/d1-lib/v2/crypto"
 )
 
 func TestGroupSeal(t *testing.T) {

--- a/id/standalone_test.go
+++ b/id/standalone_test.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/cybercryptio/d1-lib/io"
+	"github.com/cybercryptio/d1-lib/v2/io"
 )
 
 func newTestStandalone(t *testing.T) *Standalone {

--- a/id/standalone_test.go
+++ b/id/standalone_test.go
@@ -18,6 +18,7 @@ package id
 import (
 	"testing"
 
+	"context"
 	"reflect"
 
 	"github.com/cybercryptio/d1-lib/io"
@@ -41,13 +42,14 @@ func newTestStandalone(t *testing.T) *Standalone {
 }
 
 func manipulateUser(t *testing.T, uid string, standalone *Standalone) {
-	userBytes, err := standalone.ioProvider.Get([]byte(uid), DataTypeSealedUser)
+	ctx := context.Background()
+	userBytes, err := standalone.ioProvider.Get(ctx, []byte(uid), DataTypeSealedUser)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	copy(userBytes[:5], make([]byte, 5))
-	if err := standalone.ioProvider.Update([]byte(uid), DataTypeSealedUser, userBytes); err != nil {
+	if err := standalone.ioProvider.Update(ctx, []byte(uid), DataTypeSealedUser, userBytes); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -58,28 +60,29 @@ func manipulateUser(t *testing.T, uid string, standalone *Standalone) {
 
 // It is verified that GetUserGroups returns all the groups that the user is a member of.
 func TestGetIdentity(t *testing.T) {
+	ctx := context.Background()
 	standalone := newTestStandalone(t)
 
-	user, pwd, err := standalone.NewUser(ScopeEncrypt)
+	user, pwd, err := standalone.NewUser(ctx, ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	token, _, err := standalone.LoginUser(user, pwd)
+	token, _, err := standalone.LoginUser(ctx, user, pwd)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	gid1, err := standalone.NewGroup(token, ScopeEncrypt)
+	gid1, err := standalone.NewGroup(ctx, token, ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
-	gid2, err := standalone.NewGroup(token, ScopeEncrypt)
+	gid2, err := standalone.NewGroup(ctx, token, ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	identity, err := standalone.GetIdentity(token)
+	identity, err := standalone.GetIdentity(ctx, token)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,21 +96,22 @@ func TestGetIdentity(t *testing.T) {
 
 // It is verified that it is not possible to get user groups from invalid user.
 func TestGetIdentityInvalidUser(t *testing.T) {
+	ctx := context.Background()
 	standalone := newTestStandalone(t)
 
-	user, pwd, err := standalone.NewUser(ScopeEncrypt)
+	user, pwd, err := standalone.NewUser(ctx, ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	token, _, err := standalone.LoginUser(user, pwd)
+	token, _, err := standalone.LoginUser(ctx, user, pwd)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	manipulateUser(t, user, standalone)
 
-	identity, err := standalone.GetIdentity(token)
+	identity, err := standalone.GetIdentity(ctx, token)
 	if err == nil {
 		t.Fatal("Identity fetched for invalid user")
 	}
@@ -117,10 +121,11 @@ func TestGetIdentityInvalidUser(t *testing.T) {
 }
 
 func TestGetIdentityInvalidToken(t *testing.T) {
+	ctx := context.Background()
 	standalone := newTestStandalone(t)
 
 	// Token which isn't base64
-	identity, err := standalone.GetIdentity("not valid base64")
+	identity, err := standalone.GetIdentity(ctx, "not valid base64")
 	if err == nil {
 		t.Fatal("Identity fetched for invalid token")
 	}
@@ -129,7 +134,7 @@ func TestGetIdentityInvalidToken(t *testing.T) {
 	}
 
 	// Token which is base64 but is not a real token
-	identity, err = standalone.GetIdentity("bm90IGEgdmFsaWQgdG9rZW4")
+	identity, err = standalone.GetIdentity(ctx, "bm90IGEgdmFsaWQgdG9rZW4")
 	if err == nil {
 		t.Fatal("Identity fetched for invalid token")
 	}
@@ -138,11 +143,11 @@ func TestGetIdentityInvalidToken(t *testing.T) {
 	}
 
 	// Token which has been altered
-	user, pwd, err := standalone.NewUser(ScopeEncrypt)
+	user, pwd, err := standalone.NewUser(ctx, ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
-	token, _, err := standalone.LoginUser(user, pwd)
+	token, _, err := standalone.LoginUser(ctx, user, pwd)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +159,7 @@ func TestGetIdentityInvalidToken(t *testing.T) {
 	}
 	token = string(tokenBytes)
 
-	identity, err = standalone.GetIdentity(token)
+	identity, err = standalone.GetIdentity(ctx, token)
 	if err == nil {
 		t.Fatal("Identity fetched for invalid token")
 	}
@@ -172,49 +177,51 @@ func TestGetIdentityInvalidToken(t *testing.T) {
 // 2) It is verified that only user1 is authenticated with user1's password.
 // 3) It is verified that a user is not authenticated with a mistyped password.
 func TestLoginUser(t *testing.T) {
+	ctx := context.Background()
 	standalone := newTestStandalone(t)
 
-	user1, pwd1, err := standalone.NewUser(ScopeEncrypt)
+	user1, pwd1, err := standalone.NewUser(ctx, ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	user2, _, err := standalone.NewUser(ScopeEncrypt)
+	user2, _, err := standalone.NewUser(ctx, ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if _, _, err = standalone.LoginUser(user1, pwd1); err != nil {
+	if _, _, err = standalone.LoginUser(ctx, user1, pwd1); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, _, err = standalone.LoginUser(user2, pwd1); err == nil {
+	if _, _, err = standalone.LoginUser(ctx, user2, pwd1); err == nil {
 		t.Fatal("User authenticated with wrong password")
 	}
 
 	pwd1Short := pwd1[:len(pwd1)-1]
 	pwd1Long := pwd1 + "0"
 
-	if _, _, err = standalone.LoginUser(user1, pwd1Short); err == nil {
+	if _, _, err = standalone.LoginUser(ctx, user1, pwd1Short); err == nil {
 		t.Fatal("User authenticated with wrong password")
 	}
 
-	if _, _, err = standalone.LoginUser(user1, pwd1Long); err == nil {
+	if _, _, err = standalone.LoginUser(ctx, user1, pwd1Long); err == nil {
 		t.Fatal("User authenticated with wrong password")
 	}
 }
 
 func TestLoginManipulatedUser(t *testing.T) {
+	ctx := context.Background()
 	standalone := newTestStandalone(t)
 
-	user, pwd, err := standalone.NewUser(ScopeEncrypt)
+	user, pwd, err := standalone.NewUser(ctx, ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	manipulateUser(t, user, standalone)
 
-	if _, _, err = standalone.LoginUser(user, pwd); err == nil {
+	if _, _, err = standalone.LoginUser(ctx, user, pwd); err == nil {
 		t.Fatal("Invalid user able to log in")
 	}
 }
@@ -226,23 +233,24 @@ func TestLoginManipulatedUser(t *testing.T) {
 // Verify that after a password change, the new user can be authenticated with the new password and
 // can no longer be authenticated with the old one.
 func TestChangeUserPassword(t *testing.T) {
+	ctx := context.Background()
 	standalone := newTestStandalone(t)
 
-	user, pwd, err := standalone.NewUser(ScopeEncrypt)
+	user, pwd, err := standalone.NewUser(ctx, ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	newPwd, err := standalone.ChangeUserPassword(user, pwd)
+	newPwd, err := standalone.ChangeUserPassword(ctx, user, pwd)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if _, _, err := standalone.LoginUser(user, newPwd); err != nil {
+	if _, _, err := standalone.LoginUser(ctx, user, newPwd); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, _, err := standalone.LoginUser(user, pwd); err == nil {
+	if _, _, err := standalone.LoginUser(ctx, user, pwd); err == nil {
 		t.Fatal("User should not be able to authenticate with his old password after it was changed")
 	}
 }
@@ -253,40 +261,41 @@ func TestChangeUserPassword(t *testing.T) {
 
 // It is verified that a user can add/remove another user to/from groups that he is member of himself.
 func TestAddRemoveUserFromGroupsAuthorized(t *testing.T) {
+	ctx := context.Background()
 	standalone := newTestStandalone(t)
 
-	user1, pwd1, err := standalone.NewUser(ScopeEncrypt)
+	user1, pwd1, err := standalone.NewUser(ctx, ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
-	token1, _, err := standalone.LoginUser(user1, pwd1)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	user2, pwd2, err := standalone.NewUser(ScopeEncrypt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	token2, _, err := standalone.LoginUser(user2, pwd2)
+	token1, _, err := standalone.LoginUser(ctx, user1, pwd1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	gid1, err := standalone.NewGroup(token1, ScopeEncrypt)
+	user2, pwd2, err := standalone.NewUser(ctx, ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
-	gid2, err := standalone.NewGroup(token1, ScopeEncrypt)
+	token2, _, err := standalone.LoginUser(ctx, user2, pwd2)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err = standalone.AddUserToGroups(token1, user2, gid1, gid2); err != nil {
+	gid1, err := standalone.NewGroup(ctx, token1, ScopeEncrypt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gid2, err := standalone.NewGroup(ctx, token1, ScopeEncrypt)
+	if err != nil {
 		t.Fatal(err)
 	}
 
-	identity, err := standalone.GetIdentity(token2)
+	if err = standalone.AddUserToGroups(ctx, token1, user2, gid1, gid2); err != nil {
+		t.Fatal(err)
+	}
+
+	identity, err := standalone.GetIdentity(ctx, token2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -297,11 +306,11 @@ func TestAddRemoveUserFromGroupsAuthorized(t *testing.T) {
 		t.Fatal("User not correctly added to group")
 	}
 
-	if err = standalone.RemoveUserFromGroups(token2, user2, gid1, gid2); err != nil {
+	if err = standalone.RemoveUserFromGroups(ctx, token2, user2, gid1, gid2); err != nil {
 		t.Fatal(err)
 	}
 
-	identity, err = standalone.GetIdentity(token2)
+	identity, err = standalone.GetIdentity(ctx, token2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -315,99 +324,102 @@ func TestAddRemoveUserFromGroupsAuthorized(t *testing.T) {
 
 // It is verified that a user cannot add/remove another user to/from groups that he is not member of himself.
 func TestAddRemoveUserFromGroupsUnauthorized(t *testing.T) {
+	ctx := context.Background()
 	standalone := newTestStandalone(t)
 
-	user1, pwd1, err := standalone.NewUser(ScopeEncrypt)
+	user1, pwd1, err := standalone.NewUser(ctx, ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
-	token1, _, err := standalone.LoginUser(user1, pwd1)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	user2, pwd2, err := standalone.NewUser(ScopeEncrypt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	token2, _, err := standalone.LoginUser(user2, pwd2)
+	token1, _, err := standalone.LoginUser(ctx, user1, pwd1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	gid, err := standalone.NewGroup(token1, ScopeEncrypt)
+	user2, pwd2, err := standalone.NewUser(ctx, ScopeEncrypt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	token2, _, err := standalone.LoginUser(ctx, user2, pwd2)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err = standalone.RemoveUserFromGroups(token2, user1, gid); err == nil {
+	gid, err := standalone.NewGroup(ctx, token1, ScopeEncrypt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = standalone.RemoveUserFromGroups(ctx, token2, user1, gid); err == nil {
 		t.Fatal("User able to remove another user from groups without being member itself")
 	}
-	if err = standalone.AddUserToGroups(token2, user2, gid); err == nil {
+	if err = standalone.AddUserToGroups(ctx, token2, user2, gid); err == nil {
 		t.Fatal("User able to add another user to groups without being member itself")
 	}
 }
 
 // It is verified that it is not possible to add an invalid user to a group
 func TestAddInvalidUserToGroups(t *testing.T) {
+	ctx := context.Background()
 	standalone := newTestStandalone(t)
 
-	user1, pwd1, err := standalone.NewUser(ScopeEncrypt)
+	user1, pwd1, err := standalone.NewUser(ctx, ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
-	token1, _, err := standalone.LoginUser(user1, pwd1)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	user2, _, err := standalone.NewUser(ScopeEncrypt)
+	token1, _, err := standalone.LoginUser(ctx, user1, pwd1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	gid, err := standalone.NewGroup(token1, ScopeEncrypt)
+	user2, _, err := standalone.NewUser(ctx, ScopeEncrypt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gid, err := standalone.NewGroup(ctx, token1, ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	manipulateUser(t, user2, standalone)
 
-	if err = standalone.AddUserToGroups(token1, user2, gid); err == nil {
+	if err = standalone.AddUserToGroups(ctx, token1, user2, gid); err == nil {
 		t.Fatal("User able to add an invalid user to group")
 	}
 }
 
 // It is verified that it is not possible to remove an invalid user from a group
 func TestRemoveInvalidUserFromGroups(t *testing.T) {
+	ctx := context.Background()
 	standalone := newTestStandalone(t)
 
-	user1, pwd1, err := standalone.NewUser(ScopeEncrypt)
+	user1, pwd1, err := standalone.NewUser(ctx, ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
-	token1, _, err := standalone.LoginUser(user1, pwd1)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	user2, _, err := standalone.NewUser(ScopeEncrypt)
+	token1, _, err := standalone.LoginUser(ctx, user1, pwd1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	gid, err := standalone.NewGroup(token1, ScopeEncrypt)
+	user2, _, err := standalone.NewUser(ctx, ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err = standalone.AddUserToGroups(token1, user2, gid); err != nil {
+	gid, err := standalone.NewGroup(ctx, token1, ScopeEncrypt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = standalone.AddUserToGroups(ctx, token1, user2, gid); err != nil {
 		t.Fatal(err)
 	}
 
 	manipulateUser(t, user2, standalone)
 
-	if err = standalone.RemoveUserFromGroups(token1, user2, gid); err == nil {
+	if err = standalone.RemoveUserFromGroups(ctx, token1, user2, gid); err == nil {
 		t.Fatal("User able to remove an invalid user from group")
 	}
 }
@@ -417,33 +429,34 @@ func TestRemoveInvalidUserFromGroups(t *testing.T) {
 // 2) The user creates a group.
 // 3) It is verified that if the user is removed from the group, then no one can add new members to the group and hence the group is lost.
 func TestRemoveAllUsers(t *testing.T) {
+	ctx := context.Background()
 	standalone := newTestStandalone(t)
 
-	user1, pwd1, err := standalone.NewUser(ScopeEncrypt)
+	user1, pwd1, err := standalone.NewUser(ctx, ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
-	token1, _, err := standalone.LoginUser(user1, pwd1)
+	token1, _, err := standalone.LoginUser(ctx, user1, pwd1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// User 1 creates a new group and removes themselves form it
-	gid, err := standalone.NewGroup(token1, ScopeEncrypt)
+	gid, err := standalone.NewGroup(ctx, token1, ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err = standalone.RemoveUserFromGroups(token1, user1, gid); err != nil {
+	if err = standalone.RemoveUserFromGroups(ctx, token1, user1, gid); err != nil {
 		t.Fatal(err)
 	}
 
-	user2, _, err := standalone.NewUser(ScopeEncrypt)
+	user2, _, err := standalone.NewUser(ctx, ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// user1 cannot add user2 to the group
-	if err = standalone.AddUserToGroups(token1, user2, gid); err == nil {
+	if err = standalone.AddUserToGroups(ctx, token1, user2, gid); err == nil {
 		t.Fatal("User able to add another user to groups without being member itself")
 	}
 }
@@ -454,20 +467,21 @@ func TestRemoveAllUsers(t *testing.T) {
 
 // It is verified that an invalid user cannot create a new group.
 func TestNewGroupInvalidUser(t *testing.T) {
+	ctx := context.Background()
 	standalone := newTestStandalone(t)
 
-	user1, pwd1, err := standalone.NewUser(ScopeEncrypt)
+	user1, pwd1, err := standalone.NewUser(ctx, ScopeEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
-	token1, _, err := standalone.LoginUser(user1, pwd1)
+	token1, _, err := standalone.LoginUser(ctx, user1, pwd1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	manipulateUser(t, user1, standalone)
 
-	gid, err := standalone.NewGroup(token1, ScopeEncrypt)
+	gid, err := standalone.NewGroup(ctx, token1, ScopeEncrypt)
 	if err == nil {
 		t.Fatal("Invalid user able to create a new group")
 	}

--- a/id/standalone_user.go
+++ b/id/standalone_user.go
@@ -18,7 +18,7 @@ package id
 import (
 	"errors"
 
-	"github.com/cybercryptio/d1-lib/crypto"
+	"github.com/cybercryptio/d1-lib/v2/crypto"
 )
 
 // Error returned if a user cannot be authenticated, e.g. if they provide a wrong password.

--- a/id/standalone_user_test.go
+++ b/id/standalone_user_test.go
@@ -21,7 +21,7 @@ import (
 
 	"reflect"
 
-	"github.com/cybercryptio/d1-lib/crypto"
+	"github.com/cybercryptio/d1-lib/v2/crypto"
 )
 
 var groupIDs = []string{

--- a/index/index.go
+++ b/index/index.go
@@ -22,11 +22,11 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/cybercryptio/d1-lib/crypto"
-	"github.com/cybercryptio/d1-lib/data"
-	"github.com/cybercryptio/d1-lib/id"
-	"github.com/cybercryptio/d1-lib/io"
-	"github.com/cybercryptio/d1-lib/key"
+	"github.com/cybercryptio/d1-lib/v2/crypto"
+	"github.com/cybercryptio/d1-lib/v2/data"
+	"github.com/cybercryptio/d1-lib/v2/id"
+	"github.com/cybercryptio/d1-lib/v2/io"
+	"github.com/cybercryptio/d1-lib/v2/key"
 )
 
 // The length of the master key.

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -21,9 +21,9 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/cybercryptio/d1-lib/id"
-	"github.com/cybercryptio/d1-lib/io"
-	"github.com/cybercryptio/d1-lib/key"
+	"github.com/cybercryptio/d1-lib/v2/id"
+	"github.com/cybercryptio/d1-lib/v2/io"
+	"github.com/cybercryptio/d1-lib/v2/key"
 )
 
 func newTestSecureIndex(t *testing.T) SecureIndex {

--- a/io/bolt.go
+++ b/io/bolt.go
@@ -16,6 +16,7 @@
 package io
 
 import (
+	"context"
 	"time"
 
 	bolt "go.etcd.io/bbolt"
@@ -51,7 +52,7 @@ func NewBolt(path string) (Bolt, error) {
 	return Bolt{store, objectBucket}, nil
 }
 
-func (b *Bolt) Put(id []byte, dataType DataType, data []byte) error {
+func (b *Bolt) Put(_ context.Context, id []byte, dataType DataType, data []byte) error {
 	key := append(id, dataType.Bytes()...)
 	return b.store.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(b.objectBucket)
@@ -62,7 +63,7 @@ func (b *Bolt) Put(id []byte, dataType DataType, data []byte) error {
 	})
 }
 
-func (b *Bolt) Get(id []byte, dataType DataType) ([]byte, error) {
+func (b *Bolt) Get(_ context.Context, id []byte, dataType DataType) ([]byte, error) {
 	key := append(id, dataType.Bytes()...)
 	var out []byte
 	err := b.store.View(func(tx *bolt.Tx) error {
@@ -79,7 +80,7 @@ func (b *Bolt) Get(id []byte, dataType DataType) ([]byte, error) {
 	return out, nil
 }
 
-func (b *Bolt) Update(id []byte, dataType DataType, data []byte) error {
+func (b *Bolt) Update(_ context.Context, id []byte, dataType DataType, data []byte) error {
 	key := append(id, dataType.Bytes()...)
 	return b.store.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(b.objectBucket)
@@ -90,7 +91,7 @@ func (b *Bolt) Update(id []byte, dataType DataType, data []byte) error {
 	})
 }
 
-func (b *Bolt) Delete(id []byte, dataType DataType) error {
+func (b *Bolt) Delete(_ context.Context, id []byte, dataType DataType) error {
 	key := append(id, dataType.Bytes()...)
 	return b.store.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(b.objectBucket)

--- a/io/io.go
+++ b/io/io.go
@@ -18,6 +18,7 @@
 package io
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -55,17 +56,17 @@ func (d DataType) String() string {
 type Provider interface {
 	// Put sends bytes to the IO Provider. The data is identified by an ID and a data type.
 	// Should return ErrAlreadyExists if the data already exists in the IO Provider.
-	Put(id []byte, dataType DataType, data []byte) error
+	Put(ctx context.Context, id []byte, dataType DataType, data []byte) error
 
 	// Get fetches data from the IO Provider. The data is identified by an ID and a data type.
 	// Should return ErrNotFound if the data does not exist in the IO Provider.
-	Get(id []byte, dataType DataType) ([]byte, error)
+	Get(ctx context.Context, id []byte, dataType DataType) ([]byte, error)
 
 	// Update is similar to Put but updates data previously sent to the IO Provider.
 	// Should return ErrNotFound if the data does not exist in the IO Provider.
-	Update(id []byte, dataType DataType, data []byte) error
+	Update(ctx context.Context, id []byte, dataType DataType, data []byte) error
 
 	// Delete removes data previously sent to the IO Provider.
 	// Should not error if the data does not exist in the IO Provider.
-	Delete(id []byte, dataType DataType) error
+	Delete(ctx context.Context, id []byte, dataType DataType) error
 }

--- a/io/mem.go
+++ b/io/mem.go
@@ -16,6 +16,7 @@
 package io
 
 import (
+	"context"
 	"fmt"
 	"sync"
 )
@@ -35,7 +36,7 @@ func newKey(id []byte, dataType DataType) string {
 	return key
 }
 
-func (m *Mem) Put(id []byte, dataType DataType, data []byte) error {
+func (m *Mem) Put(_ context.Context, id []byte, dataType DataType, data []byte) error {
 	key := newKey(id, dataType)
 	if _, ok := m.data.Load(key); ok {
 		return ErrAlreadyExists
@@ -44,7 +45,7 @@ func (m *Mem) Put(id []byte, dataType DataType, data []byte) error {
 	return nil
 }
 
-func (m *Mem) Get(id []byte, dataType DataType) ([]byte, error) {
+func (m *Mem) Get(_ context.Context, id []byte, dataType DataType) ([]byte, error) {
 	key := newKey(id, dataType)
 	out, ok := m.data.Load(key)
 	if !ok {
@@ -54,7 +55,7 @@ func (m *Mem) Get(id []byte, dataType DataType) ([]byte, error) {
 	return data, nil
 }
 
-func (m *Mem) Update(id []byte, dataType DataType, data []byte) error {
+func (m *Mem) Update(_ context.Context, id []byte, dataType DataType, data []byte) error {
 	key := newKey(id, dataType)
 	if _, ok := m.data.Load(key); !ok {
 		return ErrNotFound
@@ -63,7 +64,7 @@ func (m *Mem) Update(id []byte, dataType DataType, data []byte) error {
 	return nil
 }
 
-func (m *Mem) Delete(id []byte, dataType DataType) error {
+func (m *Mem) Delete(_ context.Context, id []byte, dataType DataType) error {
 	key := newKey(id, dataType)
 	m.data.Delete(key)
 	return nil

--- a/io/mem_test.go
+++ b/io/mem_test.go
@@ -19,11 +19,13 @@ import (
 	"testing"
 
 	"bytes"
+	"context"
 	"errors"
 )
 
 // Test that putting and subsequently getting data returns the right bytes for all data types.
 func TestMemPutAndGet(t *testing.T) {
+	ctx := context.Background()
 	mem := NewMem()
 
 	data := []byte("mock data")
@@ -31,12 +33,12 @@ func TestMemPutAndGet(t *testing.T) {
 
 	for dt := DataType(0); dt < DataTypeEnd; dt++ {
 		testData := append(data, dt.Bytes()...)
-		err := mem.Put(id, dt, testData)
+		err := mem.Put(ctx, id, dt, testData)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		fetched, err := mem.Get(id, dt)
+		fetched, err := mem.Get(ctx, id, dt)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -49,6 +51,7 @@ func TestMemPutAndGet(t *testing.T) {
 
 // Test that putting existing data returns the right error.
 func TestMemPutAlreadyExists(t *testing.T) {
+	ctx := context.Background()
 	mem := NewMem()
 
 	data := []byte("mock data")
@@ -56,12 +59,12 @@ func TestMemPutAlreadyExists(t *testing.T) {
 
 	for dt := DataType(0); dt < DataTypeEnd; dt++ {
 		testData := append(data, dt.Bytes()...)
-		err := mem.Put(id, dt, testData)
+		err := mem.Put(ctx, id, dt, testData)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = mem.Put(id, dt, testData)
+		err = mem.Put(ctx, id, dt, testData)
 		if !errors.Is(err, ErrAlreadyExists) {
 			t.Fatalf("Expected %v but got %v", ErrAlreadyExists, err)
 		}
@@ -70,11 +73,12 @@ func TestMemPutAlreadyExists(t *testing.T) {
 
 // Test that getting non-existing data returns the right error.
 func TestMemNotFound(t *testing.T) {
+	ctx := context.Background()
 	mem := NewMem()
 
 	id := []byte("mock id")
 
-	data, err := mem.Get(id, DataTypeSealedObject)
+	data, err := mem.Get(ctx, id, DataTypeSealedObject)
 	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("Expected %v but got %v", ErrNotFound, err)
 	}
@@ -85,6 +89,7 @@ func TestMemNotFound(t *testing.T) {
 
 // Test that data can be updated correctly.
 func TestMemUpdate(t *testing.T) {
+	ctx := context.Background()
 	mem := NewMem()
 
 	data := []byte("mock data")
@@ -92,18 +97,18 @@ func TestMemUpdate(t *testing.T) {
 	id := []byte("mock id")
 
 	for dt := DataType(0); dt < DataTypeEnd; dt++ {
-		err := mem.Put(id, dt, append(data, dt.Bytes()...))
+		err := mem.Put(ctx, id, dt, append(data, dt.Bytes()...))
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		testUpdated := append(updated, dt.Bytes()...)
-		err = mem.Update(id, dt, testUpdated)
+		err = mem.Update(ctx, id, dt, testUpdated)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		fetched, err := mem.Get(id, dt)
+		fetched, err := mem.Get(ctx, id, dt)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -116,11 +121,12 @@ func TestMemUpdate(t *testing.T) {
 
 // Test that updating data that doesn't exist errors correctly.
 func TestMemUpdateNotFound(t *testing.T) {
+	ctx := context.Background()
 	mem := NewMem()
 
 	id := []byte("mock id")
 
-	err := mem.Update(id, DataTypeSealedObject, []byte("mock data"))
+	err := mem.Update(ctx, id, DataTypeSealedObject, []byte("mock data"))
 	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("Expected %v but got %v", ErrNotFound, err)
 	}
@@ -128,23 +134,24 @@ func TestMemUpdateNotFound(t *testing.T) {
 
 // Test that deleting data actually removes it.
 func TestMemDelete(t *testing.T) {
+	ctx := context.Background()
 	mem := NewMem()
 
 	data := []byte("mock data")
 	id := []byte("mock id")
 
 	for dt := DataType(0); dt < DataTypeEnd; dt++ {
-		err := mem.Put(id, dt, append(data, dt.Bytes()...))
+		err := mem.Put(ctx, id, dt, append(data, dt.Bytes()...))
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = mem.Delete(id, dt)
+		err = mem.Delete(ctx, id, dt)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		data, err := mem.Get(id, dt)
+		data, err := mem.Get(ctx, id, dt)
 		if !errors.Is(err, ErrNotFound) {
 			t.Fatalf("Expected %v but got %v", ErrNotFound, err)
 		}
@@ -156,11 +163,12 @@ func TestMemDelete(t *testing.T) {
 
 // Test that deleting non-existing data doesn't error.
 func TestMemDeleteNotFound(t *testing.T) {
+	ctx := context.Background()
 	mem := NewMem()
 
 	id := []byte("mock id")
 
-	err := mem.Delete(id, DataTypeSealedObject)
+	err := mem.Delete(ctx, id, DataTypeSealedObject)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/io/proxy.go
+++ b/io/proxy.go
@@ -2,32 +2,36 @@
 
 package io
 
+import (
+	"context"
+)
+
 // Proxy is an IO Provider that wraps other IO Providers
 // By default, it forwards calls directly to the implementation,
 // but allows you to customize the behavior as you see fit by
 // changing the individual functions as you see fit.
 type Proxy struct {
 	Implementation Provider
-	PutFunc        func(id []byte, dataType DataType, data []byte) error
-	GetFunc        func(id []byte, dataType DataType) ([]byte, error)
-	UpdateFunc     func(id []byte, dataType DataType, data []byte) error
-	DeleteFunc     func(id []byte, dataType DataType) error
+	PutFunc        func(ctx context.Context, id []byte, dataType DataType, data []byte) error
+	GetFunc        func(ctx context.Context, id []byte, dataType DataType) ([]byte, error)
+	UpdateFunc     func(ctx context.Context, id []byte, dataType DataType, data []byte) error
+	DeleteFunc     func(ctx context.Context, id []byte, dataType DataType) error
 }
 
-func (o *Proxy) Put(id []byte, dataType DataType, data []byte) error {
-	return o.PutFunc(id, dataType, data)
+func (o *Proxy) Put(ctx context.Context, id []byte, dataType DataType, data []byte) error {
+	return o.PutFunc(ctx, id, dataType, data)
 }
 
-func (o *Proxy) Get(id []byte, dataType DataType) ([]byte, error) {
-	return o.GetFunc(id, dataType)
+func (o *Proxy) Get(ctx context.Context, id []byte, dataType DataType) ([]byte, error) {
+	return o.GetFunc(ctx, id, dataType)
 }
 
-func (o *Proxy) Update(id []byte, dataType DataType, data []byte) error {
-	return o.UpdateFunc(id, dataType, data)
+func (o *Proxy) Update(ctx context.Context, id []byte, dataType DataType, data []byte) error {
+	return o.UpdateFunc(ctx, id, dataType, data)
 }
 
-func (o *Proxy) Delete(id []byte, dataType DataType) error {
-	return o.DeleteFunc(id, dataType)
+func (o *Proxy) Delete(ctx context.Context, id []byte, dataType DataType) error {
+	return o.DeleteFunc(ctx, id, dataType)
 }
 
 // NewProxy returns a basic implementation of Proxy that can be used as a basis

--- a/key/key.go
+++ b/key/key.go
@@ -17,6 +17,10 @@
 // the concept.
 package key
 
+import (
+	"context"
+)
+
 // Keys contains the master key material used by D1. All keys must be 32 bytes.
 type Keys struct {
 	// Object Encryption Key used for sealing Objects.
@@ -35,5 +39,5 @@ type Keys struct {
 // Provider is the interface a Key Provider must implement to serve keys to D1.
 type Provider interface {
 	// GetKeys returns a set of keys.
-	GetKeys() (Keys, error)
+	GetKeys(ctx context.Context) (Keys, error)
 }

--- a/key/static.go
+++ b/key/static.go
@@ -15,6 +15,10 @@
 
 package key
 
+import (
+	"context"
+)
+
 // Static implements a Key Provider which returns a fixed set of keys.
 type Static struct {
 	keys Keys
@@ -26,6 +30,6 @@ func NewStatic(keys Keys) Static {
 }
 
 // GetKeys returns the static set of keys.
-func (s *Static) GetKeys() (Keys, error) {
+func (s *Static) GetKeys(_ context.Context) (Keys, error) {
 	return s.keys, nil
 }

--- a/key/static_test.go
+++ b/key/static_test.go
@@ -18,10 +18,12 @@ package key
 import (
 	"testing"
 
+	"context"
 	"reflect"
 )
 
 func TestGetKeys(t *testing.T) {
+	ctx := context.Background()
 	keys := Keys{
 		KEK: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 		AEK: []byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
@@ -31,7 +33,7 @@ func TestGetKeys(t *testing.T) {
 
 	static := NewStatic(keys)
 
-	fetchedKeys, err := static.GetKeys()
+	fetchedKeys, err := static.GetKeys(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/utility.go
+++ b/utility.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/gofrs/uuid"
 
-	"github.com/cybercryptio/d1-lib/data"
-	"github.com/cybercryptio/d1-lib/id"
-	"github.com/cybercryptio/d1-lib/io"
+	"github.com/cybercryptio/d1-lib/v2/data"
+	"github.com/cybercryptio/d1-lib/v2/id"
+	"github.com/cybercryptio/d1-lib/v2/io"
 )
 
 // authorizeAccess checks whether the authorizing Identity is allowed to access the provided access

--- a/utility.go
+++ b/utility.go
@@ -17,6 +17,7 @@ package d1
 
 import (
 	"bytes"
+	"context"
 	"encoding/gob"
 
 	"github.com/gofrs/uuid"
@@ -50,7 +51,7 @@ func (d *D1) authorizeAccess(identity *id.Identity, scopes id.Scope, sealedAcces
 
 // putSealedObject encodes a sealed object and sends it to the IO Provider, either as a "Put" or an
 // "Update".
-func (d *D1) putSealedObject(object *data.SealedObject, update bool) error {
+func (d *D1) putSealedObject(ctx context.Context, object *data.SealedObject, update bool) error {
 	var objectBuffer bytes.Buffer
 	enc := gob.NewEncoder(&objectBuffer)
 	if err := enc.Encode(object); err != nil {
@@ -58,14 +59,14 @@ func (d *D1) putSealedObject(object *data.SealedObject, update bool) error {
 	}
 
 	if update {
-		return d.ioProvider.Update(object.OID.Bytes(), io.DataTypeSealedObject, objectBuffer.Bytes())
+		return d.ioProvider.Update(ctx, object.OID.Bytes(), io.DataTypeSealedObject, objectBuffer.Bytes())
 	}
-	return d.ioProvider.Put(object.OID.Bytes(), io.DataTypeSealedObject, objectBuffer.Bytes())
+	return d.ioProvider.Put(ctx, object.OID.Bytes(), io.DataTypeSealedObject, objectBuffer.Bytes())
 }
 
 // getSealedObject fetches bytes from the IO Provider and decodes them into a sealed object.
-func (d *D1) getSealedObject(oid uuid.UUID) (*data.SealedObject, error) {
-	objectBytes, err := d.ioProvider.Get(oid.Bytes(), io.DataTypeSealedObject)
+func (d *D1) getSealedObject(ctx context.Context, oid uuid.UUID) (*data.SealedObject, error) {
+	objectBytes, err := d.ioProvider.Get(ctx, oid.Bytes(), io.DataTypeSealedObject)
 	if err != nil {
 		return nil, err
 	}
@@ -82,13 +83,13 @@ func (d *D1) getSealedObject(oid uuid.UUID) (*data.SealedObject, error) {
 }
 
 // deleteSealedObject deletes a sealed object from the IO Provider.
-func (d *D1) deleteSealedObject(oid uuid.UUID) error {
-	return d.ioProvider.Delete(oid.Bytes(), io.DataTypeSealedObject)
+func (d *D1) deleteSealedObject(ctx context.Context, oid uuid.UUID) error {
+	return d.ioProvider.Delete(ctx, oid.Bytes(), io.DataTypeSealedObject)
 }
 
 // putSealedAccess encodes a sealed access and sends it to the IO Provider, either as a "Put" or an
 // "Update".
-func (d *D1) putSealedAccess(access *data.SealedAccess, update bool) error {
+func (d *D1) putSealedAccess(ctx context.Context, access *data.SealedAccess, update bool) error {
 	var accessBuffer bytes.Buffer
 	enc := gob.NewEncoder(&accessBuffer)
 	if err := enc.Encode(access); err != nil {
@@ -96,14 +97,14 @@ func (d *D1) putSealedAccess(access *data.SealedAccess, update bool) error {
 	}
 
 	if update {
-		return d.ioProvider.Update(access.OID.Bytes(), io.DataTypeSealedAccess, accessBuffer.Bytes())
+		return d.ioProvider.Update(ctx, access.OID.Bytes(), io.DataTypeSealedAccess, accessBuffer.Bytes())
 	}
-	return d.ioProvider.Put(access.OID.Bytes(), io.DataTypeSealedAccess, accessBuffer.Bytes())
+	return d.ioProvider.Put(ctx, access.OID.Bytes(), io.DataTypeSealedAccess, accessBuffer.Bytes())
 }
 
 // getSealedAccess fetches bytes from the IO Provider and decodes them into a sealed access.
-func (d *D1) getSealedAccess(oid uuid.UUID) (*data.SealedAccess, error) {
-	accessBytes, err := d.ioProvider.Get(oid.Bytes(), io.DataTypeSealedAccess)
+func (d *D1) getSealedAccess(ctx context.Context, oid uuid.UUID) (*data.SealedAccess, error) {
+	accessBytes, err := d.ioProvider.Get(ctx, oid.Bytes(), io.DataTypeSealedAccess)
 	if err != nil {
 		return nil, err
 	}
@@ -120,6 +121,6 @@ func (d *D1) getSealedAccess(oid uuid.UUID) (*data.SealedAccess, error) {
 }
 
 // deleteSealedAccess deletes a sealed object from the IO Provider.
-func (d *D1) deleteSealedAccess(oid uuid.UUID) error {
-	return d.ioProvider.Delete(oid.Bytes(), io.DataTypeSealedAccess)
+func (d *D1) deleteSealedAccess(ctx context.Context, oid uuid.UUID) error {
+	return d.ioProvider.Delete(ctx, oid.Bytes(), io.DataTypeSealedAccess)
 }


### PR DESCRIPTION
### Description
This PR adds a `context.Context` to the user facing API. This context is passed down to the providers, and it will help us implement logging (see DEV-334). 

Note that this is a breaking change. The second commit therefore bumps to package to v2. 

### Relevant Issues/PRs
Supports DEV-334

### Type(s) of Change (Split the PR if you check many)
- [ ] Added/updated user feature
- [x] Technical change
- [ ] Refactor
- [ ] Bugfix
- [ ] Dependency update
- [x] Added/updated tests
- [ ] Updated documentation
- [ ] Workflow/tooling changes

### Testing Checklist
- [x] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist
- [x] I have pulled in the latest changes from master.
- [ ] I have added the license header to new source code files.
- [x] I have checked the code with linting tools.
- [x] I have successfully run all tests.
- [ ] I have updated relevant CI/CD workflows.
- [x] I have updated/added relevant (internal and external) documentation (readme, doc comments, etc).
- [ ] I have updated the dependency map to reflect my changes.
- [x] I have spent some time looking over the full diff before creating this PR.
