### PR TITLE
Improve logging performance

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,42 @@
+// Copyright (C) 2022 CYBERCRYPT
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package log
+
+import (
+	"github.com/gofrs/uuid"
+	"github.com/rs/zerolog"
+)
+
+// WithMethod adds a method field to the log.
+func WithMethod(l *zerolog.Logger, method string) {
+	l.UpdateContext(func(c zerolog.Context) zerolog.Context {
+		return c.Str("method", method)
+	})
+}
+
+// WithMethod adds an bject ID field to the log.
+func WithOID(l *zerolog.Logger, oid uuid.UUID) {
+	l.UpdateContext(func(c zerolog.Context) zerolog.Context {
+		return c.Stringer("oid", oid)
+	})
+}
+
+// WithMethod adds a user ID field to the log.
+func WithUID(l *zerolog.Logger, uid string) {
+	l.UpdateContext(func(c zerolog.Context) zerolog.Context {
+		return c.Str("uid", uid)
+	})
+}


### PR DESCRIPTION
### Description
I did some profiling of the library and noticed that logging, even when disabled, took up 50% of the CPU time. Turns out that `log.With()` makes a copy of the logger. Instead, this PR uses `UpdateContext` which modifies the logger in-place. 

Also did some refactoring along the way.

### Type(s) of Change (Split the PR if you check many)
- [ ] Added/updated user feature
- [x] Technical change
- [ ] Refactor
- [ ] Bugfix
- [ ] Dependency update
- [ ] Added/updated tests
- [ ] Updated documentation
- [ ] Workflow/tooling changes

### Testing Checklist
- [ ] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist
- [x] I have pulled in the latest changes from master.
- [x] I have added the license header to new source code files.
- [x] I have checked the code with linting tools.
- [x] I have successfully run all tests.
- [ ] I have updated relevant CI/CD workflows.
- [ ] I have updated/added relevant (internal and external) documentation (readme, doc comments, etc).
- [ ] I have updated the dependency map to reflect my changes.
- [x] I have spent some time looking over the full diff before creating this PR.
